### PR TITLE
Update workflow and phpunit XML file

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,8 +47,6 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlite3, pdo_sqlite, bcmath, fileinfo, gd, imagick, xdebug
           tools: composer:v2
-          ini-values: xdebug.mode="coverage"
-          coverage: xdebug
 
       - name: Fix Imagick Policy
         run: sudo sed -i 's/none/read|write/g' /etc/ImageMagick-6/policy.xml
@@ -57,6 +55,45 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: composer test
+
+  upload-coverage:
+
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - name: Update apt
+        run: sudo apt-get update --fix-missing
+
+      - name: Install ffmpeg
+        run: sudo apt-get install ffmpeg
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install optimizers
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp
+          sudo npm install -g svgo
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlite3, pdo_sqlite, bcmath, fileinfo, gd, imagick, xdebug
+          tools: composer:v2
+          ini-values: xdebug.mode="coverage"
+          coverage: xdebug
+
+      - name: Fix Imagick Policy
+        run: sudo sed -i 's/none/read|write/g' /etc/ImageMagick-6/policy.xml
+
+      - name: Install dependencies
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         run: composer test:ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,6 +47,8 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlite3, pdo_sqlite, bcmath, fileinfo, gd, imagick, xdebug
           tools: composer:v2
+          ini-values: xdebug.mode="coverage"
+          coverage: xdebug
 
       - name: Fix Imagick Policy
         run: sudo sed -i 's/none/read|write/g' /etc/ImageMagick-6/policy.xml
@@ -55,45 +57,6 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
-
-      - name: Execute tests
-        run: composer test
-
-  upload-coverage:
-
-    runs-on: ubuntu-latest
-    needs: tests
-
-    steps:
-      - name: Update apt
-        run: sudo apt-get update --fix-missing
-
-      - name: Install ffmpeg
-        run: sudo apt-get install ffmpeg
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install optimizers
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y jpegoptim pngquant gifsicle optipng libjpeg-progs webp
-          sudo npm install -g svgo
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, sqlite3, pdo_sqlite, bcmath, fileinfo, gd, imagick, xdebug
-          tools: composer:v2
-          ini-values: xdebug.mode="coverage"
-          coverage: xdebug
-
-      - name: Fix Imagick Policy
-        run: sudo sed -i 's/none/read|write/g' /etc/ImageMagick-6/policy.xml
-
-      - name: Install dependencies
-        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         run: composer test:ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,10 +27,10 @@ jobs:
         run: sudo apt-get install ffmpeg
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: composer test:ci
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
     <testsuites>
         <testsuite name="Larupload Test Suite">
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
-
+    <coverage/>
     <php>
         <server name="APP_KEY" value="base64:b7ocQ/Py/jShJNyVqMdQU2xppSFhcULBYRwU4NsE0gw="/>
         <server name="APP_ENV" value="testing"/>
@@ -24,4 +18,9 @@
         <server name="SESSION_DRIVER" value="array"/>
         <server name="TELESCOPE_ENABLED" value="false"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
Hi, I upgraded the XML configuration schema and some of the workflow's actions to the latest version.
Due to the [deprecation](https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecation-of-v1) of `codecov/codecov-action@v1`, I upgraded it to version `3`. 
The `checkout` and `cache` actions caused the `The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/cache@v2.` warning on the summary of job's page.