### PR TITLE
Audio Style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 vendor
 .idea
+.phpunit.cache
+coverage.xml
 composer.lock

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Moreover, Larupload can calculate the dominant colors of videos and images, as w
 * Extract the width and height of the image
 * Extract width, height, and duration of the video
 * Extract the duration of the audio
+* Convert audio file formats
 * Extract dominant color from the image and video
 * Automatically create a cover image for video files
 * Possibility to upload a cover for every file

--- a/docs/advanced-usage/attachment/complete-example.md
+++ b/docs/advanced-usage/attachment/complete-example.md
@@ -41,6 +41,13 @@ class Media extends Model
                 ->image('thumbnail', 250, 250, LaruploadMediaStyle::AUTO)
                 ->image('crop_mode', 1100, 1100, LaruploadMediaStyle::CROP)
                 ->image('portrait_mode', 1000, 1000, LaruploadMediaStyle::SCALE_WIDTH)
+                ->audio('audio_wav', new Wav())
+                ->audio('audio_flac', new Flac())
+                ->audio('audio_aac', new Aac())
+                ->audio(
+                    name: 'audio_mp3',
+                    format: (new Mp3())->setAudioKiloBitrate(192)->setAudioChannels(2)
+                )
                 ->video('thumbnail', 250, 250, LaruploadMediaStyle::AUTO)
                 ->video('crop_mode', 1100, 1100, LaruploadMediaStyle::CROP)
                 ->video('portrait_mode', 1000, 1000, LaruploadMediaStyle::SCALE_WIDTH)

--- a/docs/advanced-usage/attachment/media-styles.md
+++ b/docs/advanced-usage/attachment/media-styles.md
@@ -45,6 +45,43 @@ class Media extends Model
 
 
 
+
+
+### Audio Style
+
+<table><thead><tr><th width="103" data-type="number">Index</th><th width="99">Name</th><th width="196">Type</th><th data-type="checkbox">Required</th><th width="155">Default</th><th width="515">Description</th></tr></thead><tbody><tr><td>1</td><td>name</td><td>string</td><td>true</td><td>–</td><td>style name. examples: hq, lq, ...</td></tr><tr><td>2</td><td>format</td><td>Mp3|Aac|Wav|Flac</td><td>false</td><td>Mp3</td><td>the format of the converted audio file</td></tr></tbody></table>
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Traits\Larupload;
+use FFMpeg\Format\Audio\Wav;
+
+class Media extends Model
+{
+    use Larupload;
+
+    public function attachments(): array
+    {
+        return [
+            Attachment::make('file')
+                ->audio('hq', new Wav())
+        ];
+    }
+}
+```
+
+
+
+
+
+
+
 ### Video Style
 
 <table><thead><tr><th width="103" data-type="number">Index</th><th width="99">Name</th><th width="196">Type</th><th data-type="checkbox">Required</th><th width="155">Default</th><th width="515">Description</th></tr></thead><tbody><tr><td>1</td><td>name</td><td>string</td><td>true</td><td>–</td><td>style name. examples: thumbnail, small, ...</td></tr><tr><td>2</td><td>width</td><td>?int</td><td>false</td><td>null</td><td>width of the manipulated video</td></tr><tr><td>3</td><td>height</td><td>?int</td><td>false</td><td>null</td><td>height of the manipulated video</td></tr><tr><td>4</td><td>mode</td><td>LaruploadMediaStyle</td><td>false</td><td>SCALE_HEIGHT</td><td>this argument specifies how Larupload should manipulate the uploaded video and can take on any of the following values: <code>FIT</code>, <code>AUTO</code>, <code>SCALE_WIDTH</code>, <code>SCALE_HEIGHT</code>, <code>CROP</code></td></tr><tr><td>5</td><td>format</td><td>X264</td><td>false</td><td>new X264</td><td>by default, the encoding format for video is <code>X264</code>. However, users can specify additional options for this format, including adjusting the <code>kilobitrate</code> for both <code>audio</code> and <code>video</code>. This allows for more precise configuration and optimization of the user's encoding preferences.</td></tr><tr><td>6</td><td>padding</td><td>bool</td><td>false</td><td>false</td><td>If set to <code>true</code>, padding will be applied to the video using a black color in order to fit the given dimensions.</td></tr></tbody></table>

--- a/docs/cover/upload-cover.md
+++ b/docs/cover/upload-cover.md
@@ -2,20 +2,17 @@
 
 In Larupload, covers are associated with the original files and must be uploaded using the `attach()` function. When uploading a file, you can also include a cover as the second argument. If a cover is provided, it will be assigned to the uploaded file and the [automatic cover creation](#user-content-fn-1)[^1] by the package will be prevented.
 
-<pre class="language-php"><code class="lang-php">$file = $request->file('file');
+```php
+$file = $request->file('file');
 $cover = $request->file('cover');
+# or
+$upload->attachment('file')->attach($file, $cover);
 
-<a data-footnote-ref href="#user-content-fn-2">$upload->attachment('file')->attach($file, $cover);</a>
 $upload->save();
-</code></pre>
+```
 
 
 
 
 
 [^1]: it's only available for image and videos
-
-[^2]: ```php
-    # or
-    $upload->file->attach($file, $cover);
-    ```

--- a/docs/standalone-uploader/customization.md
+++ b/docs/standalone-uploader/customization.md
@@ -21,6 +21,7 @@ $upload = Larupload::init('path')
             ->namingMethod(LaruploadNamingMethod::HASH_FILE)
             ->image('thumbnail', 1000, 750, LaruploadMediaStyle::CROP)
             ->video('thumbnail', 1000, 750, LaruploadMediaStyle::CROP)
+            ->audio('wav', new Wav())
             ->stream(
                 name: '480p',
                 width: 640,

--- a/src/Actions/Cover/GenerateCoverFromFileAction.php
+++ b/src/Actions/Cover/GenerateCoverFromFileAction.php
@@ -14,6 +14,10 @@ class GenerateCoverFromFileAction
     private readonly string $fileName;
     private readonly mixed  $ffmpegCaptureFrame;
     private array           $output;
+    private array           $availableStyles = [
+        LaruploadFileType::VIDEO, LaruploadFileType::IMAGE
+    ];
+
 
     public function __construct(private readonly UploadedFile $file, private readonly CoverActionData $data)
     {
@@ -29,6 +33,10 @@ class GenerateCoverFromFileAction
 
     public function run(string $path): array
     {
+        if (!in_array($this->data->type, $this->availableStyles)) {
+            return $this->output;
+        }
+
         Storage::disk($this->data->disk)->makeDirectory($path);
 
         $format = $this->fileFormat();

--- a/src/Actions/FixExceptionNamesAction.php
+++ b/src/Actions/FixExceptionNamesAction.php
@@ -3,6 +3,7 @@
 namespace Mostafaznv\Larupload\Actions;
 
 use Illuminate\Support\Str;
+use Mostafaznv\Larupload\DTOs\Style\Style;
 use Mostafaznv\Larupload\Larupload;
 
 /**
@@ -15,23 +16,30 @@ class FixExceptionNamesAction
 {
     public function __construct(
         private readonly string $name,
-        private readonly string $style
+        private readonly string $styleName,
+        private readonly ?Style $style = null,
     ) {}
 
-    public static function make(string $name, string $style): self
+    public static function make(string $name, string $styleName, ?Style $style = null): self
     {
-        return new self($name, $style);
+        return new self($name, $styleName, $style);
     }
 
 
     public function run(): string
     {
-        if (!in_array($this->style, [Larupload::ORIGINAL_FOLDER, Larupload::COVER_FOLDER])) {
-            if (Str::endsWith($this->name, 'svg')) {
-                return str_replace('svg', 'jpg', $this->name);
+        $name = $this->name;
+
+        if ($this->style) {
+            $name = larupload_style_path($name, $this->style->extension());
+        }
+
+        if (!in_array($this->styleName, [Larupload::ORIGINAL_FOLDER, Larupload::COVER_FOLDER])) {
+            if (Str::endsWith($name, 'svg')) {
+                return str_replace('svg', 'jpg', $name);
             }
         }
 
-        return $this->name;
+        return $name;
     }
 }

--- a/src/Concerns/Storage/Attachment/QueueAttachment.php
+++ b/src/Concerns/Storage/Attachment/QueueAttachment.php
@@ -2,15 +2,16 @@
 
 namespace Mostafaznv\Larupload\Concerns\Storage\Attachment;
 
-
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Mostafaznv\Larupload\Actions\GuessLaruploadFileTypeAction;
+use Mostafaznv\Larupload\Enums\LaruploadFileType;
 use Mostafaznv\Larupload\Jobs\ProcessFFMpeg;
 use Mostafaznv\Larupload\Larupload;
+
 
 trait QueueAttachment
 {
@@ -22,7 +23,12 @@ trait QueueAttachment
         $this->file = $this->prepareFileForFFMpegProcess();
         $this->type = GuessLaruploadFileTypeAction::make($this->file)->calc();
 
-        $this->handleVideoStyles($this->id);
+        if ($this->type == LaruploadFileType::VIDEO) {
+            $this->handleVideoStyles($this->id);
+        }
+        else if ($this->type == LaruploadFileType::AUDIO) {
+            $this->handleAudioStyles($this->id);
+        }
 
         if ($this->driverIsNotLocal() and $isLastOne) {
             Storage::disk($this->localDisk)->deleteDirectory(

--- a/src/Concerns/Storage/Attachment/RetrieveAttachment.php
+++ b/src/Concerns/Storage/Attachment/RetrieveAttachment.php
@@ -43,7 +43,8 @@ trait RetrieveAttachment
         $allStyles = array_merge(
             $staticStyles,
             array_keys($this->imageStyles),
-            array_keys($this->videoStyles)
+            array_keys($this->videoStyles),
+            array_keys($this->audioStyles)
         );
 
         foreach ($allStyles as $style) {

--- a/src/Concerns/Storage/UploadEntity/UploadEntityStyle.php
+++ b/src/Concerns/Storage/UploadEntity/UploadEntityStyle.php
@@ -3,9 +3,15 @@
 namespace Mostafaznv\Larupload\Concerns\Storage\UploadEntity;
 
 
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
 use FFMpeg\Format\Video\X264;
+use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
 use Mostafaznv\Larupload\DTOs\Style\StreamStyle;
 use Mostafaznv\Larupload\DTOs\Style\ImageStyle;
+use Mostafaznv\Larupload\DTOs\Style\Style;
 use Mostafaznv\Larupload\DTOs\Style\VideoStyle;
 use Mostafaznv\Larupload\Enums\LaruploadFileType;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
@@ -27,6 +33,13 @@ trait UploadEntityStyle
      * @var VideoStyle[]
      */
     protected array $videoStyles = [];
+
+    /**
+     * Styles for audio files
+     *
+     * @var AudioStyle[]
+     */
+    protected array $audioStyles = [];
 
     /**
      * Stream styles
@@ -53,6 +66,11 @@ trait UploadEntityStyle
         return $this->videoStyles;
     }
 
+    public function getAudioStyles(): array
+    {
+        return $this->audioStyles;
+    }
+
     public function image(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::AUTO): UploadEntities
     {
         $this->imageStyles[$name] = ImageStyle::make($name, $width, $height, $mode);
@@ -63,6 +81,13 @@ trait UploadEntityStyle
     public function video(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264 $format = new X264, bool $padding = false): UploadEntities
     {
         $this->videoStyles[$name] = VideoStyle::make($name, $width, $height, $mode, $format, $padding);
+
+        return $this;
+    }
+
+    public function audio(string $name, Mp3|Aac|Wav|Flac $format = new Mp3): UploadEntities
+    {
+        $this->audioStyles[$name] = AudioStyle::make($name, $format);
 
         return $this;
     }
@@ -81,26 +106,36 @@ trait UploadEntityStyle
         return $this;
     }
 
+    protected function getStyle(string $style): ?Style
+    {
+        $type = $this->output['type'];
+        $types = [
+            LaruploadFileType::VIDEO->name,
+            LaruploadFileType::AUDIO->name,
+            LaruploadFileType::IMAGE->name
+        ];
+
+        if (in_array($type, $types)) {
+            $styles = match ($type) {
+                LaruploadFileType::VIDEO->name => $this->videoStyles,
+                LaruploadFileType::AUDIO->name => $this->audioStyles,
+                LaruploadFileType::IMAGE->name => $this->imageStyles,
+            };
+
+            if (isset($styles[$style])) {
+                return $styles[$style];
+            }
+        }
+
+        return null;
+    }
+
     protected function styleHasFile(string $style): bool
     {
         if (in_array($style, [Larupload::ORIGINAL_FOLDER, Larupload::COVER_FOLDER])) {
             return true;
         }
 
-        $type = $this->output['type'];
-        $types = [
-            LaruploadFileType::VIDEO->name,
-            LaruploadFileType::IMAGE->name
-        ];
-
-        if (in_array($type, $types)) {
-            $styles = $type === LaruploadFileType::IMAGE->name
-                ? $this->imageStyles
-                : $this->videoStyles;
-
-            return array_key_exists($style, $styles);
-        }
-
-        return false;
+        return $this->getStyle($style) !== null;
     }
 }

--- a/src/DTOs/Style/AudioStyle.php
+++ b/src/DTOs/Style/AudioStyle.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Mostafaznv\Larupload\DTOs\Style;
+
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
+
+
+class AudioStyle extends Style
+{
+    public readonly Mp3|Aac|Wav|Flac $format;
+
+
+    public function __construct(string $name, Mp3|Aac|Wav|Flac $format = new Mp3)
+    {
+        parent::__construct($name);
+
+        $this->format = $format;
+
+    }
+
+    public static function make(string $name, Mp3|Aac|Wav|Flac $format = new Mp3): self
+    {
+        return new self($name, $format);
+    }
+
+    public function extension(): ?string
+    {
+        if ($this->format instanceof Aac) {
+            return 'aac';
+        }
+        else if ($this->format instanceof Wav) {
+            return 'wav';
+        }
+        else if ($this->format instanceof Flac) {
+            return 'flac';
+        }
+
+        return 'mp3';
+    }
+}

--- a/src/DTOs/Style/Style.php
+++ b/src/DTOs/Style/Style.php
@@ -4,6 +4,7 @@ namespace Mostafaznv\Larupload\DTOs\Style;
 
 use Exception;
 
+
 abstract class Style
 {
     public function __construct(
@@ -15,6 +16,11 @@ abstract class Style
         $this->validate();
     }
 
+
+    public function extension(): ?string
+    {
+        return null;
+    }
 
     private function validate(): void
     {

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -72,10 +72,12 @@ if (!function_exists('get_larupload_save_path')) {
      *
      * @param string $disk
      * @param string $saveTo
+     * @param string|null $extension
      * @return array
      */
-    function get_larupload_save_path(string $disk, string $saveTo): array
+    function get_larupload_save_path(string $disk, string $saveTo, ?string $extension = null): array
     {
+        $saveTo = larupload_style_path($saveTo, $extension);
         $permanent = \Illuminate\Support\Facades\Storage::disk($disk)->path($saveTo);
         list($path, $name) = split_larupload_path($saveTo);
 
@@ -184,6 +186,26 @@ if (!function_exists('file_is_valid')) {
         }
 
         return true;
+    }
+}
+
+if (!function_exists('larupload_style_path')) {
+    /**
+     * Change path extension
+     *
+     * @param string $path
+     * @param string|null $extension
+     * @return string
+     */
+    function larupload_style_path(string $path, ?string $extension): string
+    {
+        if ($extension) {
+            $info = pathinfo($path);
+
+            return $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $extension;
+        }
+
+        return $path;
     }
 }
 

--- a/src/Storage/FFMpeg/FFMpeg.php
+++ b/src/Storage/FFMpeg/FFMpeg.php
@@ -14,12 +14,14 @@ use FFMpeg\Media\Video;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
 use Mostafaznv\Larupload\DTOs\FFMpeg\FFMpegMeta;
+use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
 use Mostafaznv\Larupload\DTOs\Style\ImageStyle;
 use Mostafaznv\Larupload\DTOs\Style\StreamStyle;
 use Mostafaznv\Larupload\DTOs\Style\VideoStyle;
 use Mostafaznv\Larupload\Enums\LaruploadImageLibrary;
 use Mostafaznv\Larupload\Storage\Image;
 use Psr\Log\LoggerInterface;
+
 
 class FFMpeg
 {
@@ -120,6 +122,15 @@ class FFMpeg
         larupload_finalize_save($this->disk, $saveTo);
 
         return $dominantColor;
+    }
+
+    public function audio(AudioStyle $style, string $saveTo): void
+    {
+        $saveTo = get_larupload_save_path($this->disk, $saveTo, $style->extension());
+
+        $this->media->save($style->format, $saveTo['local']);
+
+        larupload_finalize_save($this->disk, $saveTo);
     }
 
     public function manipulate(VideoStyle $style, string $saveTo): void

--- a/tests/Feature/AudioStyleTest.php
+++ b/tests/Feature/AudioStyleTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadHeavyTestModel;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadLightTestModel;
+use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
+use Illuminate\Support\Str;
+use Mostafaznv\Larupload\Test\Support\TestAttachmentBuilder;
+
+
+it('will generate audio styles correctly', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model->withAllAudios();
+    $model = save($model, mp3());
+
+    $attachment = $model->attachment('main_file');
+    $mp3 = urlToAudio($attachment->url('audio_mp3'));
+    $wav = urlToAudio($attachment->url('audio_wav'));
+    $flac = urlToAudio($attachment->url('audio_flac'));
+
+    expect($attachment->url('cover'))
+        ->toBeNull()
+        // mp3
+        ->and($attachment->url('audio_mp3'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($mp3->width)
+        ->toBeNull()
+        ->and($mp3->height)
+        ->toBeNull()
+        ->and($mp3->duration)
+        ->toBe(67)
+        // wav
+        ->and($attachment->url('audio_wav'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($wav->width)
+        ->toBeNull()
+        ->and($wav->height)
+        ->toBeNull()
+        ->and($wav->duration)
+        ->toBe(67)
+        // flac
+        ->and($attachment->url('audio_flac'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($flac->width)
+        ->toBeNull()
+        ->and($flac->height)
+        ->toBeNull()
+        ->and($flac->duration)
+        ->toBe(67);
+
+})->with('models');
+
+it('will generate audio styles in standalone mode correctly', function() {
+    $upload = Larupload::init('uploader')
+        ->audio('audio_mp3', new Mp3())
+        ->audio('audio_wav', new Wav())
+        ->audio('audio_flac', new Flac())
+        ->upload(mp3());
+
+    $mp3 = urlToVideo($upload->audio_mp3);
+    $wav = urlToVideo($upload->audio_wav);
+    $flac = urlToVideo($upload->audio_flac);
+
+    expect($upload->cover)
+        ->toBeNull()
+        // mp3
+        ->and($upload->audio_mp3)
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($mp3->width)
+        ->toBeNull()
+        ->and($mp3->height)
+        ->toBeNull()
+        ->and($mp3->duration)
+        ->toBe(67)
+        // wav
+        ->and($upload->audio_wav)
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($wav->width)
+        ->toBeNull()
+        ->and($wav->height)
+        ->toBeNull()
+        ->and($wav->duration)
+        ->toBe(67)
+        // flac
+        ->and($upload->audio_flac)
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($flac->width)
+        ->toBeNull()
+        ->and($flac->height)
+        ->toBeNull()
+        ->and($flac->duration)
+        ->toBe(67);
+});
+
+it('will generate audio styles correctly when secure-ids is enabled', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
+
+    $model = new ($model::class);
+    $model->setAttachments(
+        TestAttachmentBuilder::make($model->mode)->withWavAudio()->toArray()
+    );
+    $model = save($model, mp3());
+
+    $attachment = $model->attachment('main_file');
+    $id = $attachment->meta('id');
+    $wav = urlToVideo($attachment->url('audio_wav'));
+
+    expect(Str::isUlid($id))->toBeTrue()
+        // cover
+        ->and($attachment->url('cover'))
+        ->toBeNull()
+        // wav
+        ->and($attachment->url('audio_wav'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($wav->width)
+        ->toBeNull()
+        ->and($wav->height)
+        ->toBeNull()
+        ->and($wav->duration)
+        ->toBe(67);
+
+})->with('models');

--- a/tests/Feature/DownloadTest.php
+++ b/tests/Feature/DownloadTest.php
@@ -62,6 +62,21 @@ it('will download custom video styles', function(LaruploadHeavyTestModel|Laruplo
 
 })->with('models');
 
+it('will download custom audio styles', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model->setAttachments(
+        TestAttachmentBuilder::make($model->mode)->withWavAudio()->toArray()
+    );
+
+    $model = save($model, mp3());
+    $attachment = $model->attachment('main_file');
+
+    expect($attachment->download('audio_wav'))
+        ->toBeInstanceOf(StreamedResponse::class)
+        ->getStatusCode()
+        ->toBe(200);
+
+})->with('models');
+
 it('will return null for styles that do not exist', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
     $model = save($model, jpg());
     $attachment = $model->attachment('main_file');

--- a/tests/Feature/FFMpegQueueTest.php
+++ b/tests/Feature/FFMpegQueueTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use FFMpeg\Format\Audio\Wav;
 use FFMpeg\Format\Video\X264;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Bus;
 use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
@@ -15,23 +17,40 @@ use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
 
 beforeEach(function() {
     Bus::fake();
+    Queue::fake();
     Event::fake(LaruploadFFMpegQueueFinished::class);
 
     config()->set('larupload.ffmpeg.queue', true);
 });
 
-it('will process ffmpeg through queue', function() {
-    save(LaruploadTestModels::QUEUE->instance(), mp4());
+it('will process ffmpeg through queue', function(UploadedFile $file) {
+    Bus::assertNotDispatched(ProcessFFMpeg::class);
+
+    save(LaruploadTestModels::QUEUE->instance(), $file);
 
     Bus::assertDispatched(ProcessFFMpeg::class);
-});
 
-it('will process ffmpeg through queue in standalone mode', function() {
+})->with([
+    mp4(),
+    mp3()
+]);
+
+it('will process ffmpeg through queue in standalone mode [video]', function() {
+    Bus::assertNotDispatched(ProcessFFMpeg::class);
+
     Larupload::init('uploader')
         ->video('landscape', 400)
         ->upload(mp4());
 
-    save(LaruploadTestModels::QUEUE->instance(), mp4());
+    Bus::assertDispatched(ProcessFFMpeg::class);
+});
+
+it('will process ffmpeg through queue in standalone mode [audio]', function() {
+    Bus::assertNotDispatched(ProcessFFMpeg::class);
+
+    Larupload::init('uploader')
+        ->audio('audio_wav', new Wav())
+        ->upload(mp3());
 
     Bus::assertDispatched(ProcessFFMpeg::class);
 });
@@ -56,6 +75,26 @@ it('will create video styles through queue process', function() {
     expect($urls->landscape)->toBeExists();
 });
 
+it('will create audio styles through queue process', function() {
+    $model = LaruploadTestModels::QUEUE->instance();
+    $model = save($model, mp3());
+
+    $urls = $model->attachment('main_file')->urls();
+
+    expect($urls->original)
+        ->toBeExists()
+        ->and($urls->cover)
+        ->toBeNull()
+        ->and($urls->audio_wav)
+        ->toNotExists();
+
+    $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
+    $process = new ProcessFFMpeg($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+    expect($urls->audio_wav)->toBeExists();
+});
+
 it('will create video styles through queue process in standalone mode', function() {
     $name = 'uploader';
     $standalone = Larupload::init($name)->video('landscape', 400);
@@ -74,6 +113,26 @@ it('will create video styles through queue process in standalone mode', function
     $process->handle();
 
     expect($uploader->landscape)->toBeExists();
+});
+
+it('will create audio styles through queue process in standalone mode', function() {
+    $name = 'uploader';
+    $standalone = Larupload::init($name)->audio('audio_wav', new Wav);
+    $uploader = $standalone->upload(mp3());
+
+    expect($uploader->original)
+        ->toBeExists()
+        ->and($uploader->cover)
+        ->toBeNull()
+        ->and($uploader->audio_wav)
+        ->toNotExists();
+
+    $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
+    $serializedClass = base64_encode(serialize($standalone));
+    $process = new ProcessFFMpeg($queue->id, $uploader->meta->id, $name, Larupload::class, $serializedClass);
+    $process->handle();
+
+    expect($uploader->audio_wav)->toBeExists();
 });
 
 it('will create streams through queue process', function() {
@@ -121,7 +180,7 @@ it('will create streams through queue process in standalone mode', function() {
 
 });
 
-it('can queue ffmpeg for remote disks and deletes local files after finishing the process', function() {
+it('can queue ffmpeg for remote disks and deletes local files after finishing the process', function(UploadedFile $file, int $expectedS3Files1, int $expectedS3Files2) {
     # init
     $disk = 's3';
     $localDisk = config()->get('larupload.local-disk');
@@ -129,7 +188,7 @@ it('can queue ffmpeg for remote disks and deletes local files after finishing th
 
     # save model
     $model = LaruploadTestModels::REMOTE_QUEUE->instance();
-    $model = save($model, mp4());
+    $model = save($model, $file);
 
     # prepare for assertions
     $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
@@ -139,7 +198,7 @@ it('can queue ffmpeg for remote disks and deletes local files after finishing th
 
     # assertions 1
     expect($s3Files)
-        ->toHaveCount(2)
+        ->toHaveCount($expectedS3Files1)
         ->and($localFiles)
         ->toHaveCount(1)
         ->and($localFiles[0])
@@ -156,12 +215,15 @@ it('can queue ffmpeg for remote disks and deletes local files after finishing th
 
     // assertions 2
     expect($s3Files)
-        ->toHaveCount(7)
+        ->toHaveCount($expectedS3Files2)
         ->and($localFiles)
         ->toHaveCount(0);
-});
+})->with([
+    [mp4(), 2, 7],
+    [mp3(), 1, 2],
+]);
 
-it('can queue ffmpeg for remote disks and deletes local files after finishing the process in standalone mode', function() {
+it('can queue ffmpeg for remote disks and deletes local files after finishing the process in standalone mode [video]', function() {
     # init
     $name = 'uploader';
     $disk = 's3';
@@ -203,9 +265,58 @@ it('can queue ffmpeg for remote disks and deletes local files after finishing th
         ->toHaveCount(8)
         ->and($localFiles)
         ->toHaveCount(0);
+
+    Storage::disk($disk)->deleteDirectory('/');
 });
 
-it('can queue ffmpeg when using secure-ids', function() {
+it('can queue ffmpeg for remote disks and deletes local files after finishing the process in standalone mode [audio]', function() {
+    # init
+    $name = 'uploader';
+    $disk = 's3';
+    $localDisk = config()->get('larupload.local-disk');
+    Storage::fake($disk);
+    $standalone = Larupload::init($name)
+        ->disk($disk)
+        ->audio('audio_wav', new Wav);
+
+    # upload
+    $uploader = $standalone->upload(mp3());
+
+    # prepare for assertions
+    $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
+    $serializedClass = base64_encode(serialize($standalone));
+    $s3Files = Storage::disk($disk)->allFiles();
+    $localFiles = Storage::disk($localDisk)->allFiles();
+
+
+    # assertions 1
+    expect($s3Files)
+        ->toHaveCount(2)
+        ->and($localFiles)
+        ->toHaveCount(1)
+        ->and($localFiles[0])
+        ->toEndWith($uploader->meta->name);
+
+
+    # run queue
+    $process = new ProcessFFMpeg($queue->id, $uploader->meta->id, $name, Larupload::class, $serializedClass);
+    $process->handle();
+
+    # prepare for assertions
+    $s3Files = Storage::disk($disk)->allFiles();
+    $localFiles = Storage::disk($localDisk)->allFiles();
+
+    // assertions 2
+    expect($s3Files)
+        ->toHaveCount(3)
+        ->and($localFiles)
+        ->toHaveCount(0);
+
+
+    Storage::disk($disk)->deleteDirectory('/');
+});
+
+it('can queue ffmpeg when using secure-ids [video]', function() {
     config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
 
     $model = LaruploadTestModels::QUEUE->instance();
@@ -227,7 +338,29 @@ it('can queue ffmpeg when using secure-ids', function() {
     expect($urls->landscape)->toBeExists();
 });
 
-it('can queue ffmpeg when using secure-ids in standalone mode', function() {
+it('can queue ffmpeg when using secure-ids [audio]', function() {
+    config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
+
+    $model = LaruploadTestModels::QUEUE->instance();
+    $model = save($model, mp3());
+
+    $urls = $model->attachment('main_file')->urls();
+
+    expect($urls->original)
+        ->toBeExists()
+        ->and($urls->cover)
+        ->toBeExists()
+        ->and($urls->audio_wav)
+        ->toNotExists();
+
+    $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
+    $process = new ProcessFFMpeg($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+    expect($urls->audio_wav)->toBeExists();
+});
+
+it('can queue ffmpeg when using secure-ids in standalone mode [video]', function() {
     config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
 
     $name = 'uploader';
@@ -273,9 +406,55 @@ it('can queue ffmpeg when using secure-ids in standalone mode', function() {
     expect($urls->landscape)->toBeExists();
 });
 
-it('will change queue status after processing queue', function() {
+it('can queue ffmpeg when using secure-ids in standalone mode [audio]', function() {
+    config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
+
+    $name = 'uploader';
+    $standalone = Larupload::init($name)->audio('audio_wav', new Wav);
+    $uploader = $standalone->upload(mp3());
+
+    expect($uploader->original)
+        ->toBeExists()
+        ->and($uploader->cover)
+        ->toBeExists()
+        ->and($uploader->audio_wav)
+        ->toNotExists();
+
+    $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
+    $serializedClass = base64_encode(serialize($standalone));
+    $process = new ProcessFFMpeg($queue->id, $uploader->meta->id, $name, Larupload::class, $serializedClass);
+    $process->handle();
+
+    expect($uploader->audio_wav)->toBeExists();
+
+
+
+
+
+
+
     $model = LaruploadTestModels::QUEUE->instance();
-    $model = save($model, mp4());
+    $model = save($model, mp3());
+
+    $urls = $model->attachment('main_file')->urls();
+
+    expect($urls->original)
+        ->toBeExists()
+        ->and($urls->cover)
+        ->toBeExists()
+        ->and($urls->audio_wav)
+        ->toNotExists();
+
+    $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
+    $process = new ProcessFFMpeg($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+    expect($urls->audio_wav)->toBeExists();
+});
+
+it('will change queue status after processing queue', function(UploadedFile $file) {
+    $model = LaruploadTestModels::QUEUE->instance();
+    $model = save($model, $file);
     $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
 
     expect($queue)
@@ -294,11 +473,15 @@ it('will change queue status after processing queue', function() {
         ->toBeObject()
         ->and($queue->status)
         ->toBe(1);
-});
 
-it('will fire an event when process is finished', function() {
+})->with([
+    mp4(),
+    mp3(),
+]);
+
+it('will fire an event when process is finished', function(UploadedFile $file) {
     $model = LaruploadTestModels::QUEUE->instance();
-    $model = save($model, mp4());
+    $model = save($model, $file);
     $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
 
     Event::assertNotDispatched(LaruploadFFMpegQueueFinished::class);
@@ -307,11 +490,15 @@ it('will fire an event when process is finished', function() {
     $process->handle();
 
     Event::assertDispatched(LaruploadFFMpegQueueFinished::class);
-});
 
-it('will update queue record whit error message, when process failed', function() {
+})->with([
+    mp4(),
+    mp3(),
+]);
+
+it('will update queue record whit error message, when process failed', function(UploadedFile $file) {
     $model = LaruploadTestModels::QUEUE->instance();
-    $model = save($model, mp4());
+    $model = save($model, $file);
     $queue = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->first();
 
     expect($queue->message)->toBeNull();
@@ -325,7 +512,10 @@ it('will update queue record whit error message, when process failed', function(
 
     expect($queue->message)->toBeTruthy();
 
-})->throws(Exception::class);
+})->throws(Exception::class)->with([
+    mp4(),
+    mp3(),
+]);
 
 it('can load queue relationships of model', function() {
     $model = LaruploadTestModels::QUEUE->instance();
@@ -350,7 +540,7 @@ it('will throw exception if max-queue-num exceeds', function() {
     $model = LaruploadTestModels::QUEUE->instance();
 
     save($model, mp4());
-    save($model, mp4());
-    save($model, mp4());
+    save($model, mp3());
+    save($model, mp3());
 
 })->throws(HttpResponseException::class);

--- a/tests/Feature/ResponseTest.php
+++ b/tests/Feature/ResponseTest.php
@@ -9,7 +9,9 @@ use Mostafaznv\Larupload\Test\Support\Models\LaruploadLightTestModel;
 use Illuminate\Support\Facades\Storage;
 
 $properties = [
-    'original', 'cover', 'stream', 'small_size', 'small', 'medium', 'landscape', 'portrait', 'exact', 'auto', 'meta'
+    'original', 'cover', 'stream', 'small_size', 'small', 'medium',
+    'audio_mp3', 'audio_wav', 'audio_flac',
+    'landscape', 'portrait', 'exact', 'auto', 'meta'
 ];
 
 it('will return larupload object in toArray function', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) use ($properties) {

--- a/tests/Feature/SecureIdsTest.php
+++ b/tests/Feature/SecureIdsTest.php
@@ -136,7 +136,7 @@ it('will work with light mode', function () {
         ->toBeExists();
 });
 
-it('will work with ffmpeg class', function () {
+it('will work with ffmpeg class [video]', function () {
     config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
 
     $model = LaruploadTestModels::HEAVY->instance();
@@ -165,5 +165,30 @@ it('will work with ffmpeg class', function () {
         ->and($attachment->url('landscape'))
         ->toContain($id)
         ->toBeExists();
+});
 
+it('will work with ffmpeg class [audio]', function () {
+    config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
+
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model->setAttachments(
+        TestAttachmentBuilder::make($model->mode)->withWavAudio()->toArray()
+    );
+
+    $model = save($model, mp3());
+
+    $attachment = $model->attachment('main_file');
+    $id = $attachment->meta('id');
+
+    expect(Str::isUlid($id))->toBeTrue()
+        ->and($attachment->url())
+        ->toContain($id)
+        ->toBeExists()
+        //
+        ->and($attachment->url('cover'))
+        ->toBeNull()
+        //
+        ->and($attachment->url('audio_wav'))
+        ->toContain($id)
+        ->toBeExists();
 });

--- a/tests/Feature/UploadEntityTest.php
+++ b/tests/Feature/UploadEntityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Wav;
 use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
@@ -63,6 +65,21 @@ it('can return video registered styles', function() {
         ->and(array_keys($styles))
         ->toBe([
             'sd', 'hd'
+        ]);
+});
+
+it('can return audio registered styles', function() {
+    $this->attachment->audio('audio_wav', new Wav);
+    $this->attachment->audio('audio_aac', new Aac());
+
+    $styles = $this->attachment->getAudioStyles();
+
+    expect($styles)
+        ->toBeArray()
+        ->toHaveCount(2)
+        ->and(array_keys($styles))
+        ->toBe([
+            'audio_wav', 'audio_aac'
         ]);
 });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -109,6 +109,21 @@ function urlToVideo(string $url): FFMpegMeta
     return $ffmpeg->getMeta();
 }
 
+function urlToAudio(string $url): FFMpegMeta
+{
+    $baseUrl = url('/');
+    $url = str_replace($baseUrl, '', $url);
+    $path = public_path($url);
+
+    $fileName = pathinfo($path, PATHINFO_FILENAME);
+    $disk = config('larupload.disk');
+
+    $file = new UploadedFile($path, $fileName, null, null, true);
+    $ffmpeg = new FFMpeg($file, $disk, 10);
+
+    return $ffmpeg->getMeta();
+}
+
 function urlsToPath(AttachmentProxy $attachment, array $exclude = []): array
 {
     $paths = [];

--- a/tests/Support/Models/LaruploadQueueTestModel.php
+++ b/tests/Support/Models/LaruploadQueueTestModel.php
@@ -24,6 +24,7 @@ class LaruploadQueueTestModel extends Model
         return TestAttachmentBuilder::make($this->mode)
             ->withLandscapeVideo()
             ->with480pStream()
+            ->withWavAudio()
             ->toArray();
     }
 }

--- a/tests/Support/Models/LaruploadRemoteQueueTestModel.php
+++ b/tests/Support/Models/LaruploadRemoteQueueTestModel.php
@@ -23,6 +23,7 @@ class LaruploadRemoteQueueTestModel extends Model
     {
         return TestAttachmentBuilder::make($this->mode, 's3')
             ->withLandscapeVideo()
+            ->withWavAudio()
             ->with480pStream()
             ->toArray();
     }

--- a/tests/Support/Models/Traits/TestAttachments.php
+++ b/tests/Support/Models/Traits/TestAttachments.php
@@ -45,6 +45,13 @@ trait TestAttachments
         );
     }
 
+    public function withAllAudios(): array
+    {
+        return $this->setAttachments(
+            TestAttachmentBuilder::make($this->mode)->withAllAudios()->toArray()
+        );
+    }
+
     public function withStreams(): array
     {
         return $this->setAttachments(

--- a/tests/Support/TestAttachmentBuilder.php
+++ b/tests/Support/TestAttachmentBuilder.php
@@ -2,6 +2,10 @@
 
 namespace Mostafaznv\Larupload\Test\Support;
 
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
 use FFMpeg\Format\Video\X264;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
 use Mostafaznv\Larupload\Enums\LaruploadMode;
@@ -81,6 +85,36 @@ class TestAttachmentBuilder
             ->withPortraitImage()
             ->withExactImage()
             ->withAutoImage();
+
+        return $this;
+    }
+
+    public function withMp3Audio(): self
+    {
+        $this->attachment = $this->attachment->audio('audio_mp3', new Mp3);
+
+        return $this;
+    }
+
+    public function withWavAudio(): self
+    {
+        $this->attachment = $this->attachment->audio('audio_wav', new Wav);
+
+        return $this;
+    }
+
+    public function withFlacAudio(): self
+    {
+        $this->attachment = $this->attachment->audio('audio_flac', new Flac);
+
+        return $this;
+    }
+
+    public function withAllAudios(): self
+    {
+        $this->withMp3Audio()
+            ->withWavAudio()
+            ->withFlacAudio();
 
         return $this;
     }
@@ -199,7 +233,7 @@ class TestAttachmentBuilder
 
     public function withAll(): self
     {
-        $this->withAllImages()->withAllVideosAndStreams();
+        $this->withAllImages()->withAllVideosAndStreams()->withAllAudios();
 
         return $this;
     }

--- a/tests/Unit/AudioStyleTest.php
+++ b/tests/Unit/AudioStyleTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
+
+
+it('will throw exception when name is numeric', function() {
+    AudioStyle::make('12');
+
+})->throws(Exception::class, 'Style name [12] is numeric. please use string name for your style');
+

--- a/tests/Unit/FixExceptionNamesActionTest.php
+++ b/tests/Unit/FixExceptionNamesActionTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use FFMpeg\Format\Audio\Aac;
+use Mostafaznv\Larupload\Actions\FixExceptionNamesAction;
+use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
+use Mostafaznv\Larupload\DTOs\Style\ImageStyle;
+use Mostafaznv\Larupload\Larupload;
+
+
+it('wont convert svg to jpg for original/cover styles', function(string $style) {
+    $path = 'path/to/file.svg';
+
+    $res = FixExceptionNamesAction::make($path, $style)->run();
+
+    expect($res)->toBe($path);
+
+})->with([
+    Larupload::ORIGINAL_FOLDER,
+    Larupload::COVER_FOLDER
+]);
+
+it('will convert svg to jpg for custom styles', function() {
+    $res = FixExceptionNamesAction::make('path/to/file.svg', 'custom-style')->run();
+
+    expect($res)->toBe('path/to/file.jpg');
+});
+
+it('will change file extension based on style', function() {
+    $style = AudioStyle::make('custom-style', new Aac());
+    $res = FixExceptionNamesAction::make('path/to/file.mp3', $style->name, $style)->run();
+
+    expect($res)->toBe('path/to/file.aac');
+});
+
+it('wont change file extension if style doesnt have custom extension', function() {
+    $style = ImageStyle::make('custom-style', 100, 100);
+    $path = 'path/to/file.png';
+    $res = FixExceptionNamesAction::make($path, $style->name, $style)->run();
+
+    expect($res)->toBe($path);
+});
+

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -85,6 +85,45 @@ it('can generate save path', function() {
         ]);
 });
 
+it('can generate save path with custom extension', function() {
+    $path = 'path/to/file.png';
+    $newPath = 'path/to/file.jpg';
+    $localPath = config('filesystems.disks.local.root');
+
+    $result = get_larupload_save_path('local', $path, 'jpg');
+
+    expect($result)
+        ->toBeArray()
+        ->toHaveCount(5)
+        ->toMatchArray([
+            'path'      => 'path/to',
+            'name'      => 'file.jpg',
+            'temp'      => null,
+            'local'     => $localPath . '/' . $newPath,
+            'permanent' => $localPath . '/' . $newPath,
+        ]);
+
+
+    $carbon = Carbon::createFromFormat('Y-m-d H:i:s', '1990-09-20 07:10:48');
+    $time = $carbon->unix();
+    testTime()->freeze($carbon);
+
+    $result = get_larupload_save_path('s3', $path, 'jpg');
+
+    $tempPath = larupload_temp_dir();
+
+    expect($result)
+        ->toBeArray()
+        ->toHaveCount(5)
+        ->toMatchArray([
+            'path'      => 'path/to',
+            'name'      => 'file.jpg',
+            'temp'      => $tempPath . "/$time-file.jpg",
+            'local'     => $tempPath . "/$time-file.jpg",
+            'permanent' => $newPath,
+        ]);
+});
+
 it('can upload file to remote disks', function() {
     $driver = 's3';
     $file = pdf();
@@ -171,3 +210,24 @@ it('can check if instance of uploaded-file is valid or not', function() {
 
     file_is_valid(png(2), 'file', 'cover');
 })->throws(RuntimeException::class);
+
+
+it('will return path unchanged if extension is null', function() {
+    $original = 'path/to/file.mp3';
+    $path = larupload_style_path($original, null);
+
+    expect($path)->toBe($original);
+});
+
+it('will return path unchanged if extension is an empty string', function() {
+    $original = 'path/to/file.mp3';
+    $path = larupload_style_path($original, '');
+
+    expect($path)->toBe($original);
+});
+
+it('will change path using the given extension', function() {
+    $path = larupload_style_path('path/to/file.mp3', 'wav');
+
+    expect($path)->toBe('path/to/file.wav');
+});


### PR DESCRIPTION
This pull request introduces support for handling audio styles in addition to the existing video and image styles. The key changes include adding a new `AudioStyle` class, updating various methods to handle audio files, and adding tests to ensure the new functionality works correctly.

### Support for Audio Styles:

* [`src/DTOs/Style/AudioStyle.php`](diffhunk://#diff-7e82af2ea90173b2ac9b4e7e7678667f75ba73c2b08165e604a8088ecb988275R1-R43): Introduced a new `AudioStyle` class to handle different audio formats such as MP3, AAC, WAV, and FLAC.

### Updates to Existing Functionality:

* [`src/Concerns/Storage/Attachment/QueueAttachment.php`](diffhunk://#diff-7cc2373f652526c15be9791f3c39b8df2f253c07dea597145d7775661dbaadc4R26-R31): Updated the `handleFFMpegQueue` method to process audio styles similarly to video styles.
* [`src/Concerns/Storage/Attachment/StyleAttachment.php`](diffhunk://#diff-73ebbe8150c467eca19d1c7e521dad58ffc9df5ac2df705fee469993ea686cb5R56-R78): Added methods to handle audio styles and updated the `prepareStylePath` method to include audio styles. [[1]](diffhunk://#diff-73ebbe8150c467eca19d1c7e521dad58ffc9df5ac2df705fee469993ea686cb5R56-R78) [[2]](diffhunk://#diff-73ebbe8150c467eca19d1c7e521dad58ffc9df5ac2df705fee469993ea686cb5R108-R123) [[3]](diffhunk://#diff-73ebbe8150c467eca19d1c7e521dad58ffc9df5ac2df705fee469993ea686cb5L100-R139) [[4]](diffhunk://#diff-73ebbe8150c467eca19d1c7e521dad58ffc9df5ac2df705fee469993ea686cb5L120-R160)
* [`src/Concerns/Storage/UploadEntity/UploadEntityStyle.php`](diffhunk://#diff-3b4013c70ac0a61e842aca09f3fc84c920081c42137ce1a61bfbeb1d662886c4R37-R43): Added properties and methods for managing audio styles. [[1]](diffhunk://#diff-3b4013c70ac0a61e842aca09f3fc84c920081c42137ce1a61bfbeb1d662886c4R37-R43) [[2]](diffhunk://#diff-3b4013c70ac0a61e842aca09f3fc84c920081c42137ce1a61bfbeb1d662886c4R88-R94) [[3]](diffhunk://#diff-3b4013c70ac0a61e842aca09f3fc84c920081c42137ce1a61bfbeb1d662886c4L84-R139)

### Utility and Helper Functions:

* [`src/Helpers/Utils.php`](diffhunk://#diff-e1fcfb79c5908191d4ef531322745d81f967406df35535054b3978b529620185R192-R211): Added a new helper function `larupload_style_path` to change the path extension based on the style.

### Testing:

* [`tests/Feature/AudioStyleTest.php`](diffhunk://#diff-7e165768c0fb75a6e98a8d6f779fee3307242b8f98c3a44063d6c8dd86b72f41R1-R138): Added tests to verify the correct generation of audio styles and their properties.


closes #28