### PR TITLE
merge dev to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Moreover, Larupload can calculate the dominant colors of videos and images, as w
 * Upload with 2 different strategies: ORM-based and Standalone
 * Use different drivers
 * Ability to resize/crop photos and videos
+* Ability to convert video files into custom video or audio formats
 * Ability to create multiple sizes of videos and images
 * Ability to create HTTP Live Streaming (HLS) from video sources
 * Ability to hide the real ID of model records by using different ID formats (ULID, UUID and ...)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Moreover, Larupload can calculate the dominant colors of videos and images, as w
 * Upload with 2 different strategies: ORM-based and Standalone
 * Use different drivers
 * Ability to resize/crop photos and videos
+* Ability to convert video files into custom video or audio formats
 * Ability to create multiple sizes of videos and images
 * Ability to create HTTP Live Streaming (HLS) from video sources
 * Ability to hide the real ID of model records by using different ID formats (ULID, UUID and ...)

--- a/docs/advanced-usage/attachment/complete-example.md
+++ b/docs/advanced-usage/attachment/complete-example.md
@@ -5,6 +5,9 @@
 
 namespace App\Models;
 
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
 use FFMpeg\Format\Video\X264;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -16,6 +19,7 @@ use Mostafaznv\Larupload\Enums\LaruploadStyleMode;
 use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Traits\Larupload;
+
 
 class Media extends Model
 {
@@ -51,6 +55,7 @@ class Media extends Model
                 ->video('thumbnail', 250, 250, LaruploadMediaStyle::AUTO)
                 ->video('crop_mode', 1100, 1100, LaruploadMediaStyle::CROP)
                 ->video('portrait_mode', 1000, 1000, LaruploadMediaStyle::SCALE_WIDTH)
+                ->video(name: 'mp3', format: new Mp3)
                 ->video(
                     name: 'auto',
                     width: 300,

--- a/docs/advanced-usage/attachment/media-styles.md
+++ b/docs/advanced-usage/attachment/media-styles.md
@@ -84,7 +84,7 @@ class Media extends Model
 
 ### Video Style
 
-<table><thead><tr><th width="103" data-type="number">Index</th><th width="99">Name</th><th width="196">Type</th><th data-type="checkbox">Required</th><th width="155">Default</th><th width="515">Description</th></tr></thead><tbody><tr><td>1</td><td>name</td><td>string</td><td>true</td><td>–</td><td>style name. examples: thumbnail, small, ...</td></tr><tr><td>2</td><td>width</td><td>?int</td><td>false</td><td>null</td><td>width of the manipulated video</td></tr><tr><td>3</td><td>height</td><td>?int</td><td>false</td><td>null</td><td>height of the manipulated video</td></tr><tr><td>4</td><td>mode</td><td>LaruploadMediaStyle</td><td>false</td><td>SCALE_HEIGHT</td><td>this argument specifies how Larupload should manipulate the uploaded video and can take on any of the following values: <code>FIT</code>, <code>AUTO</code>, <code>SCALE_WIDTH</code>, <code>SCALE_HEIGHT</code>, <code>CROP</code></td></tr><tr><td>5</td><td>format</td><td>X264</td><td>false</td><td>new X264</td><td>by default, the encoding format for video is <code>X264</code>. However, users can specify additional options for this format, including adjusting the <code>kilobitrate</code> for both <code>audio</code> and <code>video</code>. This allows for more precise configuration and optimization of the user's encoding preferences.</td></tr><tr><td>6</td><td>padding</td><td>bool</td><td>false</td><td>false</td><td>If set to <code>true</code>, padding will be applied to the video using a black color in order to fit the given dimensions.</td></tr></tbody></table>
+<table><thead><tr><th width="103" data-type="number">Index</th><th width="99">Name</th><th width="196">Type</th><th data-type="checkbox">Required</th><th width="155">Default</th><th width="515">Description</th></tr></thead><tbody><tr><td>1</td><td>name</td><td>string</td><td>true</td><td>–</td><td>style name. examples: thumbnail, small, ...</td></tr><tr><td>2</td><td>width</td><td>?int</td><td>false</td><td>null</td><td>width of the manipulated video</td></tr><tr><td>3</td><td>height</td><td>?int</td><td>false</td><td>null</td><td>height of the manipulated video</td></tr><tr><td>4</td><td>mode</td><td>LaruploadMediaStyle</td><td>false</td><td>SCALE_HEIGHT</td><td>this argument specifies how Larupload should manipulate the uploaded video and can take on any of the following values: <code>FIT</code>, <code>AUTO</code>, <code>SCALE_WIDTH</code>, <code>SCALE_HEIGHT</code>, <code>CROP</code></td></tr><tr><td>5</td><td>format</td><td>X264 | WebM | Ogg | Mp3 | Aac | Wav | Flac</td><td>false</td><td>new X264</td><td>by default, the encoding format for video is <code>X264</code>. However, users can specify additional <code>video</code>/<code>audio</code>formats and options, including adjusting the <code>kilobitrate</code> for both <code>audio</code> and <code>video</code>. This allows for more precise configuration and optimization of the user's encoding preferences.</td></tr><tr><td>6</td><td>padding</td><td>bool</td><td>false</td><td>false</td><td>If set to <code>true</code>, padding will be applied to the video using a black color in order to fit the given dimensions.</td></tr></tbody></table>
 
 ```php
 <?php
@@ -95,6 +95,8 @@ use Illuminate\Database\Eloquent\Model;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Traits\Larupload;
+use FFMpeg\Format\Audio\Mp3;
+
 
 class Media extends Model
 {
@@ -106,6 +108,7 @@ class Media extends Model
             Attachment::make('file')
                 ->video('thumbnail', 250, 250, LaruploadMediaStyle::CROP)
                 ->video('landscape', 1100, 1100, LaruploadMediaStyle::AUTO)
+                ->video(name: 'mp3', format: new Mp3)
         ];
     }
 }

--- a/src/Concerns/Storage/UploadEntity/FFMpegUploadEntity.php
+++ b/src/Concerns/Storage/UploadEntity/FFMpegUploadEntity.php
@@ -3,7 +3,12 @@
 namespace Mostafaznv\Larupload\Concerns\Storage\UploadEntity;
 
 
+use FFMpeg\Media\Audio;
+use FFMpeg\Media\Video;
 use Illuminate\Http\UploadedFile;
+use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
+use Mostafaznv\Larupload\DTOs\Style\Style;
+use Mostafaznv\Larupload\DTOs\Style\VideoStyle;
 use Mostafaznv\Larupload\Storage\FFMpeg\FFMpeg;
 
 trait FFMpegUploadEntity
@@ -24,9 +29,27 @@ trait FFMpegUploadEntity
     protected int $ffmpegMaxQueueNum;
 
 
-    protected function ffmpeg(UploadedFile $file = null): FFMpeg
+    protected function ffmpeg(UploadedFile $file = null, AudioStyle|VideoStyle|null $style = null): FFMpeg
     {
-        if (!isset($this->ffmpeg) or $file) {
+        $force = false;
+
+        if ($style and isset($this->ffmpeg)) {
+            $media = $this->ffmpeg->getMedia();
+
+            // @codeCoverageIgnoreStart
+            // it's an unlikely scenario, however, we must consider it
+            if ($style instanceof AudioStyle and $media instanceof Video) {
+                $force = true;
+            }
+            // @codeCoverageIgnoreEnd
+
+            if ($style instanceof VideoStyle and $media instanceof Audio) {
+                $force = true;
+            }
+        }
+
+
+        if (!isset($this->ffmpeg) or $file or $force) {
             $this->ffmpeg = new FFMpeg($this->file, $this->disk, $this->dominantColorQuality);
         }
 

--- a/src/Concerns/Storage/UploadEntity/UploadEntityStyle.php
+++ b/src/Concerns/Storage/UploadEntity/UploadEntityStyle.php
@@ -7,6 +7,8 @@ use FFMpeg\Format\Audio\Aac;
 use FFMpeg\Format\Audio\Flac;
 use FFMpeg\Format\Audio\Mp3;
 use FFMpeg\Format\Audio\Wav;
+use FFMpeg\Format\Video\Ogg;
+use FFMpeg\Format\Video\WebM;
 use FFMpeg\Format\Video\X264;
 use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
 use Mostafaznv\Larupload\DTOs\Style\StreamStyle;
@@ -78,7 +80,7 @@ trait UploadEntityStyle
         return $this;
     }
 
-    public function video(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264 $format = new X264, bool $padding = false): UploadEntities
+    public function video(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264|WebM|Ogg|Mp3|Aac|Wav|Flac $format = new X264, bool $padding = false): UploadEntities
     {
         $this->videoStyles[$name] = VideoStyle::make($name, $width, $height, $mode, $format, $padding);
 

--- a/src/DTOs/Style/VideoStyle.php
+++ b/src/DTOs/Style/VideoStyle.php
@@ -3,15 +3,22 @@
 namespace Mostafaznv\Larupload\DTOs\Style;
 
 use Exception;
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
+use FFMpeg\Format\Video\Ogg;
+use FFMpeg\Format\Video\WebM;
 use FFMpeg\Format\Video\X264;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
 
+
 class VideoStyle extends Style
 {
-    public readonly LaruploadMediaStyle $mode;
-    public readonly X264 $format;
+    public readonly LaruploadMediaStyle            $mode;
+    public readonly X264|WebM|Ogg|Mp3|Aac|Wav|Flac $format;
 
-    public function __construct(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264 $format = new X264, bool $padding = false)
+    public function __construct(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264|WebM|Ogg|Mp3|Aac|Wav|Flac $format = new X264, bool $padding = false)
     {
         parent::__construct($name, $width, $height, $padding);
 
@@ -21,14 +28,54 @@ class VideoStyle extends Style
         $this->validateDimension();
     }
 
-    public static function make(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264 $format = new X264, bool $padding = false): self
+    public static function make(string $name, ?int $width = null, ?int $height = null, LaruploadMediaStyle $mode = LaruploadMediaStyle::SCALE_HEIGHT, X264|WebM|Ogg|Mp3|Aac|Wav|Flac $format = new X264, bool $padding = false): self
     {
         return new self($name, $width, $height, $mode, $format, $padding);
     }
 
 
+    public function audioFormats(): array
+    {
+        return [
+            Mp3::class, Aac::class, Wav::class, Flac::class
+        ];
+    }
+
+    public function isAudioFormat(): bool
+    {
+        return in_array(get_class($this->format), $this->audioFormats());
+    }
+
+    public function extension(): ?string
+    {
+        if ($this->format instanceof WebM) {
+            return 'webm';
+        }
+        else if ($this->format instanceof Ogg) {
+            return 'ogg';
+        }
+        else if ($this->format instanceof Mp3) {
+            return 'mp3';
+        }
+        else if ($this->format instanceof Aac) {
+            return 'aac';
+        }
+        else if ($this->format instanceof Wav) {
+            return 'wav';
+        }
+        else if ($this->format instanceof Flac) {
+            return 'flac';
+        }
+
+        return 'mp4';
+    }
+
     private function validateDimension(): void
     {
+        if ($this->isAudioFormat()) {
+            return;
+        }
+
         if ($this->mode === LaruploadMediaStyle::SCALE_HEIGHT) {
             if ($this->width === null or $this->width === 0) {
                 throw new Exception(

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -201,8 +201,9 @@ if (!function_exists('larupload_style_path')) {
     {
         if ($extension) {
             $info = pathinfo($path);
+            $path = $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $extension;
 
-            return $info['dirname'] . DIRECTORY_SEPARATOR . $info['filename'] . '.' . $extension;
+            return ltrim($path, './');
         }
 
         return $path;

--- a/src/Storage/FFMpeg/FFMpeg.php
+++ b/src/Storage/FFMpeg/FFMpeg.php
@@ -85,6 +85,11 @@ class FFMpeg
                 // @codeCoverageIgnoreEnd
             }
 
+            // in some formats like webm, duration is not available in streams, so we should get it from format
+            if (!isset($meta['duration'])) {
+                $meta['duration'] = $this->media->getFormat()->get('duration', 0);
+            }
+
             $this->meta = FFMpegMeta::make(
                 width: $meta['width'] ?? null,
                 height: $meta['height'] ?? null,
@@ -135,7 +140,7 @@ class FFMpeg
 
     public function manipulate(VideoStyle $style, string $saveTo): void
     {
-        $saveTo = get_larupload_save_path($this->disk, $saveTo);
+        $saveTo = get_larupload_save_path($this->disk, $saveTo, $style->extension());
 
         $style->mode->ffmpegResizeFilter()
             ? $this->resize($style)

--- a/tests/Feature/VideoStyleTest.php
+++ b/tests/Feature/VideoStyleTest.php
@@ -104,6 +104,87 @@ it('will generate video styles correctly', function(LaruploadHeavyTestModel|Laru
 
 })->with('models');
 
+it('will generate videos with custom video/audio formats', function() {
+    $model = new LaruploadHeavyTestModel;
+    $model->withAllCustomFormatVideos();
+    $model = save($model, mp4());
+
+    $attachment = $model->attachment('main_file');
+    $cover = urlToVideo($attachment->url('cover'));
+    $webm = urlToVideo($attachment->url('webm'));
+    $ogg = urlToVideo($attachment->url('ogg'));
+    $mp3 = urlToAudio($attachment->url('mp3'));
+    $wav = urlToAudio($attachment->url('wav'));
+    $flac = urlToAudio($attachment->url('flac'));
+
+    expect($attachment->url('cover'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($cover->width)
+        ->toBe(500)
+        ->and($cover->height)
+        ->toBe(500)
+        ->and($cover->duration)
+        ->toBe(0)
+        // web
+        ->and($attachment->url('webm'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($webm->width)
+        ->toBe(400)
+        ->and($webm->height)
+        ->toBe(224)
+        ->and($webm->duration)
+        ->toBe(5)
+        // ogg
+        ->and($attachment->url('ogg'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($ogg->width)
+        ->toBe(400)
+        ->and($ogg->height)
+        ->toBe(224)
+        ->and($ogg->duration)
+        ->toBe(5)
+        // mp3
+        ->and($attachment->url('mp3'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($mp3->width)
+        ->toBeNull()
+        ->and($mp3->height)
+        ->toBeNull()
+        ->and($mp3->duration)
+        ->toBe(5)
+        // wav
+        ->and($attachment->url('wav'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($wav->width)
+        ->toBeNull()
+        ->and($wav->height)
+        ->toBeNull()
+        ->and($wav->duration)
+        ->toBe(5)
+        // flac
+        ->and($attachment->url('flac'))
+        ->toBeTruthy()
+        ->toBeString()
+        ->toBeExists()
+        ->and($flac->width)
+        ->toBeNull()
+        ->and($flac->height)
+        ->toBeNull()
+        ->and($flac->duration)
+        ->toBe(5);
+
+});
+
 it('will generate stream correctly', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
     $model->withStreams();
     $model = save($model, mp4());
@@ -237,7 +318,7 @@ it('will generate stream in standalone mode correctly', function() {
         ->stream(
             name: '720p',
             width: 1280,
-            height:  720,
+            height: 720,
             format: (new X264)
                 ->setKiloBitrate(1000)
                 ->setAudioKiloBitrate(64)

--- a/tests/Support/Models/Traits/TestAttachments.php
+++ b/tests/Support/Models/Traits/TestAttachments.php
@@ -45,6 +45,13 @@ trait TestAttachments
         );
     }
 
+    public function withAllCustomFormatVideos(): array
+    {
+        return $this->setAttachments(
+            TestAttachmentBuilder::make($this->mode)->withAllCustomFormatVideos()->toArray()
+        );
+    }
+
     public function withAllAudios(): array
     {
         return $this->setAttachments(

--- a/tests/Support/TestAttachmentBuilder.php
+++ b/tests/Support/TestAttachmentBuilder.php
@@ -2,10 +2,11 @@
 
 namespace Mostafaznv\Larupload\Test\Support;
 
-use FFMpeg\Format\Audio\Aac;
 use FFMpeg\Format\Audio\Flac;
 use FFMpeg\Format\Audio\Mp3;
 use FFMpeg\Format\Audio\Wav;
+use FFMpeg\Format\Video\Ogg;
+use FFMpeg\Format\Video\WebM;
 use FFMpeg\Format\Video\X264;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
 use Mostafaznv\Larupload\Enums\LaruploadMode;
@@ -176,6 +177,58 @@ class TestAttachmentBuilder
         return $this;
     }
 
+    public function withWebmVideo(): self
+    {
+        $this->attachment = $this->attachment->video(
+            name: 'webm',
+            width: 400,
+            format: new WebM
+        );
+
+        return $this;
+    }
+
+    public function withOggVideo(): self
+    {
+        $this->attachment = $this->attachment->video(
+            name: 'ogg',
+            width: 400,
+            format: new Ogg
+        );
+
+        return $this;
+    }
+
+    public function withMp3Video(): self
+    {
+        $this->attachment = $this->attachment->video(
+            name: 'mp3',
+            format: new Mp3
+        );
+
+        return $this;
+    }
+
+    public function withWavVideo(): self
+    {
+        $this->attachment = $this->attachment->video(
+            name: 'wav',
+            format: new Wav
+        );
+
+        return $this;
+    }
+
+    public function withFlacVideo(): self
+    {
+        $this->attachment = $this->attachment->video(
+            name: 'flac',
+            format: new Flac
+        );
+
+        return $this;
+    }
+
     public function withAllVideos(): self
     {
         $this->withSmallSizeVideo()
@@ -185,6 +238,17 @@ class TestAttachmentBuilder
             ->withPortraitVideo()
             ->withExactVideo()
             ->withAutoVideo();
+
+        return $this;
+    }
+
+    public function withAllCustomFormatVideos(): self
+    {
+        $this->withOggVideo()
+            ->withMp3Video()
+            ->withWavVideo()
+            ->withWebmVideo()
+            ->withFlacVideo();
 
         return $this;
     }

--- a/tests/Unit/AudioStyleTest.php
+++ b/tests/Unit/AudioStyleTest.php
@@ -1,5 +1,9 @@
 <?php
 
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
 use Mostafaznv\Larupload\DTOs\Style\AudioStyle;
 
 
@@ -8,3 +12,14 @@ it('will throw exception when name is numeric', function() {
 
 })->throws(Exception::class, 'Style name [12] is numeric. please use string name for your style');
 
+it('will set correct extensions for each audio format', function(Aac|Wav|Flac|Mp3 $format, string $expected) {
+    $style = AudioStyle::make('test', $format);
+
+    expect($style->extension())->toBe($expected);
+
+})->with([
+    [new Aac(), 'aac'],
+    [new Wav(), 'wav'],
+    [new Flac(), 'flac'],
+    [new Mp3(), 'mp3'],
+]);

--- a/tests/Unit/FFMpegTest.php
+++ b/tests/Unit/FFMpegTest.php
@@ -18,9 +18,11 @@ use Mostafaznv\Larupload\DTOs\Style\ImageStyle;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
 use Illuminate\Support\Facades\Storage;
 
+
 beforeEach(function() {
     $this->ffmpeg = new FFMpeg(mp4(), 'local', 10);
 });
+
 
 it('will return an instance of ffmpeg', function() {
     $ffmpeg = new FFMpeg(mp4(), 'local', 10);
@@ -30,7 +32,7 @@ it('will return an instance of ffmpeg', function() {
     expect($ffmpeg->getMedia())->toBeInstanceOf(Audio::class);
 });
 
-it('will meta for video files', function() {
+it('will return meta for video files', function() {
     $ffmpeg = new FFMpeg(mp4(), 'local', 10);
     $meta = $ffmpeg->getMeta();
 
@@ -44,7 +46,7 @@ it('will meta for video files', function() {
         ->toBe(5);
 });
 
-it('will meta for audio files', function() {
+it('will return meta for audio files', function() {
     $ffmpeg = new FFMpeg(mp3(), 'local', 10);
     $meta = $ffmpeg->getMeta();
 

--- a/tests/Unit/UtilsTest.php
+++ b/tests/Unit/UtilsTest.php
@@ -231,3 +231,9 @@ it('will change path using the given extension', function() {
 
     expect($path)->toBe('path/to/file.wav');
 });
+
+it('trims the extra dot at the beginning of the path when dirname is null', function() {
+    $path = larupload_style_path('file.mp3', 'wav');
+
+    expect($path)->toBe('file.wav');
+});

--- a/tests/Unit/VideoStyleTest.php
+++ b/tests/Unit/VideoStyleTest.php
@@ -1,7 +1,15 @@
 <?php
 
+use FFMpeg\Format\Audio\Aac;
+use FFMpeg\Format\Audio\Flac;
+use FFMpeg\Format\Audio\Mp3;
+use FFMpeg\Format\Audio\Wav;
+use FFMpeg\Format\Video\Ogg;
+use FFMpeg\Format\Video\WebM;
+use FFMpeg\Format\Video\X264;
 use Mostafaznv\Larupload\DTOs\Style\VideoStyle;
 use Mostafaznv\Larupload\Enums\LaruploadMediaStyle;
+
 
 $cropOrFitDataset = [
     'd1' => [LaruploadMediaStyle::CROP, null, 100],
@@ -9,6 +17,7 @@ $cropOrFitDataset = [
     'd3' => [LaruploadMediaStyle::FIT, null, 100],
     'd4' => [LaruploadMediaStyle::FIT, 100, null]
 ];
+
 
 it('will throw exception when name is numeric', function() {
     VideoStyle::make('12', 100, 100);
@@ -34,3 +43,57 @@ it('will throw exception when mode is AUTO and both width and height are not set
     VideoStyle::make('test', null, null, LaruploadMediaStyle::AUTO);
 
 })->throws(Exception::class, 'Width and height are required when you are in auto mode');
+
+it('will return audio formats array correctly', function() {
+    $style = VideoStyle::make('test', format: new Mp3);
+
+    expect($style->audioFormats())
+        ->toContain(Mp3::class)
+        ->toContain(Aac::class)
+        ->toContain(Wav::class)
+        ->toContain(Flac::class);
+});
+
+it('will guess audio formats correctly', function(X264|WebM|Ogg|Mp3|Aac|Wav|Flac $format, bool $expected) {
+    $style = VideoStyle::make('test', 300, 300, LaruploadMediaStyle::AUTO, $format);
+
+    expect($style->isAudioFormat())->toBe($expected);
+
+})->with([
+    [new X264(), false],
+    [new WebM(), false],
+    [new Ogg(), false],
+
+    [new Aac(), true],
+    [new Wav(), true],
+    [new Flac(), true],
+    [new Mp3(), true],
+]);
+
+it('wont throw an dimension exception if format is audio', function(Mp3|Aac|Wav|Flac $format) {
+    $style = VideoStyle::make('test', format: $format);
+
+    expect($style)->toBeInstanceOf(VideoStyle::class);
+
+})->with([
+    new Mp3(),
+    new Aac(),
+    new Wav(),
+    new Flac(),
+]);
+
+it('will set correct extensions for each video format', function(X264|WebM|Ogg|Mp3|Aac|Wav|Flac $format, string $expected) {
+    $style = VideoStyle::make('test', 300, 300, LaruploadMediaStyle::AUTO, $format);
+
+    expect($style->extension())->toBe($expected);
+
+})->with([
+    [new X264(), 'mp4'],
+    [new WebM(), 'webm'],
+    [new Ogg(), 'ogg'],
+
+    [new Aac(), 'aac'],
+    [new Wav(), 'wav'],
+    [new Flac(), 'flac'],
+    [new Mp3(), 'mp3'],
+]);


### PR DESCRIPTION
This pull request introduces support for additional audio and video formats in the Larupload package. The key changes include the addition of new format classes, updates to handle these formats in various methods, and new tests to ensure proper functionality.

### Support for new audio and video formats:

* [`src/Concerns/Storage/Attachment/StyleAttachment.php`](diffhunk://#diff-73ebbe8150c467eca19d1c7e521dad58ffc9df5ac2df705fee469993ea686cb5R98-R111): Added support for handling audio formats in the `handleVideoStyles` method.
* [`src/Concerns/Storage/UploadEntity/UploadEntityStyle.php`](diffhunk://#diff-3b4013c70ac0a61e842aca09f3fc84c920081c42137ce1a61bfbeb1d662886c4L81-R83): Updated the `video` method to accept new audio and video formats.
* [`src/DTOs/Style/VideoStyle.php`](diffhunk://#diff-e705627a7655e41eb11dd915c9f9b9d7e1fe6237c11f541c378a23e3fcd5b4adR6-R21): Added new audio format classes and methods to handle audio formats. [[1]](diffhunk://#diff-e705627a7655e41eb11dd915c9f9b9d7e1fe6237c11f541c378a23e3fcd5b4adR6-R21) [[2]](diffhunk://#diff-e705627a7655e41eb11dd915c9f9b9d7e1fe6237c11f541c378a23e3fcd5b4adL24-R78)

### Codebase improvements:

* [`src/Storage/FFMpeg/FFMpeg.php`](diffhunk://#diff-d84430276da0c43c1f093ae861d515b3549dc7c621fafed380b915776af09f63R88-R92): Improved `getMeta` and `manipulate` methods to handle new formats and ensure duration is correctly retrieved. [[1]](diffhunk://#diff-d84430276da0c43c1f093ae861d515b3549dc7c621fafed380b915776af09f63R88-R92) [[2]](diffhunk://#diff-d84430276da0c43c1f093ae861d515b3549dc7c621fafed380b915776af09f63L138-R143)

### Testing enhancements:

* [`tests/Feature/VideoStyleTest.php`](diffhunk://#diff-91aab575d20ac3044e74bda14e631811e16e17e1aa7856ffd2ecf4ba193f670fR107-R187): Added tests to verify video generation with custom formats.
* [`tests/Unit/VideoStyleTest.php`](diffhunk://#diff-c1263b10241afd71c6eed66454123ff4051d15f8546558ab43919112c67e3405R46-R99): Added tests to validate audio format handling and correct extension assignment.
* [`tests/Support/TestAttachmentBuilder.php`](diffhunk://#diff-f778ebfb3bd25e8396f1e01f4a048a61d1147c992613f514af3dd901c057c65fR180-R231): Added methods to support new custom format videos in tests. [[1]](diffhunk://#diff-f778ebfb3bd25e8396f1e01f4a048a61d1147c992613f514af3dd901c057c65fR180-R231) [[2]](diffhunk://#diff-f778ebfb3bd25e8396f1e01f4a048a61d1147c992613f514af3dd901c057c65fR245-R255)



#28 