### PR TITLE
feat: increase max length for `original file name` column

### DIFF
--- a/src/Database/Schema/Blueprint.php
+++ b/src/Database/Schema/Blueprint.php
@@ -25,7 +25,7 @@ class Blueprint
             $table->string("{$name}_file_id", 36)->nullable();
 
             if (config('larupload.store-original-file-name', false)) {
-                $table->string("{$name}_file_original_name", 85)->nullable()->index();
+                $table->string("{$name}_file_original_name", 255)->nullable()->index();
             }
 
             $table->unsignedInteger("{$name}_file_size")->nullable()->index();

--- a/tests/Feature/BlueprintTest.php
+++ b/tests/Feature/BlueprintTest.php
@@ -180,7 +180,7 @@ it('will create file_original_name column in heavy mode', function() {
         ->and($columns['file_file_original_name'])
         ->toBeArray()
         ->toHaveKey('type', 'string')
-        ->toHaveKey('length', 85)
+        ->toHaveKey('length', 255)
         ->toHaveKey('nullable', true);
 });
 


### PR DESCRIPTION
Updated the `file_original_name` column length from 85 to 255 in both schema creation logic and related tests. This ensures better compatibility and allows for longer file names to be stored.