### PR TITLE
path

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -79,6 +79,7 @@
     * [Generate URL for particular style](download/generate-download-link/generate-url-for-particular-style.md)
     * [Generate URL for all styles](download/generate-download-link/generate-url-for-all-styles.md)
   * [Generate Download Response](download/generate-download-response.md)
+* [Path](path.md)
 * [Meta](meta.md)
 * [Get Attachments](get-attachments.md)
 * [API Resources](api-resources.md)

--- a/docs/path.md
+++ b/docs/path.md
@@ -1,0 +1,30 @@
+# Path
+
+The `path` method returns the actual path of an attachment file. Call it without any arguments to retrieve the path of the original file. Pass a style name as an argument to retrieve the path of a specific style.
+
+{% tabs %}
+{% tab title="Original file" %}
+```php
+$model->attachment('file')->path();
+```
+{% endtab %}
+
+{% tab title="Particular style" %}
+```php
+$model->attachment('file')->path('cover');
+```
+{% endtab %}
+{% endtabs %}
+
+You can use any generated style name.
+
+```php
+$model->attachment('file')->path('thumbnail');
+$model->attachment('file')->path('cover');
+```
+
+{% hint style="info" %}
+Use `path()` when you need the local file path for server-side processing.
+
+Use `url()` when you need a public link to the file.
+{% endhint %}

--- a/src/Concerns/Storage/Attachment/RetrieveAttachment.php
+++ b/src/Concerns/Storage/Attachment/RetrieveAttachment.php
@@ -89,10 +89,6 @@ trait RetrieveAttachment
         $path = $this->prepareStylePath($style);
 
         if ($path) {
-            dd(
-                $path,
-                Storage::disk($this->disk)->path($path),
-            );
             return Storage::disk($this->disk)->path($path);
         }
 

--- a/src/Concerns/Storage/Attachment/RetrieveAttachment.php
+++ b/src/Concerns/Storage/Attachment/RetrieveAttachment.php
@@ -80,6 +80,25 @@ trait RetrieveAttachment
         return null;
     }
 
+    public function path(string $style = Larupload::ORIGINAL_FOLDER): ?string
+    {
+        if (isset($this->file) and $this->file === false) {
+            return null;
+        }
+
+        $path = $this->prepareStylePath($style);
+
+        if ($path) {
+            dd(
+                $path,
+                Storage::disk($this->disk)->path($path),
+            );
+            return Storage::disk($this->disk)->path($path);
+        }
+
+        return null;
+    }
+
     public function download(string $style = Larupload::ORIGINAL_FOLDER): StreamedResponse|RedirectResponse|null
     {
         if (isset($this->file) and $this->file === false) {

--- a/src/Storage/Proxy/AttachmentProxy.php
+++ b/src/Storage/Proxy/AttachmentProxy.php
@@ -45,6 +45,11 @@ readonly class AttachmentProxy
         return $this->attachment->url($style);
     }
 
+    public function path(string $style = Larupload::ORIGINAL_FOLDER): ?string
+    {
+        return $this->attachment->path($style);
+    }
+
     public function download(string $style = Larupload::ORIGINAL_FOLDER): StreamedResponse|RedirectResponse|null
     {
         return $this->attachment->download($style);

--- a/tests/Feature/MagicPropertiesTest.php
+++ b/tests/Feature/MagicPropertiesTest.php
@@ -27,6 +27,7 @@ it('will return attachment on retrieving attachment property', function(Laruploa
             'meta',
             'urls',
             'url',
+            'path',
             'download',
             'handleFFMpegQueue',
         ]);

--- a/tests/Feature/PathTest.php
+++ b/tests/Feature/PathTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadHeavyTestModel;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadLightTestModel;
+use Mostafaznv\Larupload\Test\Support\TestAttachmentBuilder;
+
+
+it('generates realpath for original file', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model = save($model, jpg());
+    $path = $model->attachment('main_file')->path();
+
+    expect($path)
+        ->toBeString()
+        ->toContain('/original/')
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+})->with('models');
+
+it('generates realpath for cover file', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model = save($model, jpg());
+    $path = $model->attachment('main_file')->path('cover');
+
+    expect($path)
+        ->toBeString()
+        ->toContain('/cover/')
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+})->with('models');
+
+it('generates realpath for custom image styles', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model->setAttachments(
+        TestAttachmentBuilder::make($model->mode)->withLandscapeImage()->toArray()
+    );
+
+    $model = save($model, jpg());
+    $attachment = $model->attachment('main_file');
+    $path = $model->attachment('main_file')->path('landscape');
+
+    expect($path)
+        ->toBeString()
+        ->toContain('/landscape/')
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+})->with('models');
+
+it('generates realpath for custom video styles', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model->setAttachments(
+        TestAttachmentBuilder::make($model->mode)->withSmallVideo()->toArray()
+    );
+
+    $model = save($model, mp4());
+    $path = $model->attachment('main_file')->path('small');
+
+    expect($path)
+        ->toBeString()
+        ->toContain('/small/')
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+})->with('models');
+
+it('generates realpath for custom audio styles', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model->setAttachments(
+        TestAttachmentBuilder::make($model->mode)->withWavAudio()->toArray()
+    );
+
+    $model = save($model, mp3());
+    $path = $model->attachment('main_file')->path('audio_wav');
+
+    expect($path)
+        ->toBeString()
+        ->toContain('/audio-wav/')
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+})->with('models');
+
+it('returns null for styles that do not exist', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model = save($model, jpg());
+    $path = $model->attachment('main_file')->path('not-exists');
+
+    expect($path)->toBeNull();
+
+})->with('models');
+
+it('generates realpath for original file when secure-ids is enabled', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
+
+    $model = $model::class;
+    $model = save(new $model, jpg());
+    $path = $model->attachment('main_file')->path();
+
+    expect($path)
+        ->toBeString()
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+})->with('models');
+
+it('returns null, if file is set and the value is `false`', function(LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    $model = save($model, jpg());
+    $path = $model->attachment('main_file')->path();
+
+    expect($path)
+        ->toBeString()
+        ->and(file_exists($path))
+        ->toBeTrue();
+
+    $model->main_file = false;
+    $path = $model->attachment('main_file')->path();
+
+    expect($path)->toBeNull();
+
+})->with('models');
+
+it('returns realpath when storage driver is not local', function() {
+    Storage::fake('s3');
+    $attachments = [
+        Attachment::make('main_file')->disk('s3')
+    ];
+
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model->setAttachments($attachments);
+
+    $model = save($model, jpg());
+    $path = $model->attachment('main_file')->path();
+
+    expect($path)
+        ->toBeString()
+        ->and(file_exists($path))
+        ->toBeTrue();
+});


### PR DESCRIPTION
This pull request introduces support for retrieving the local file path of an attachment through a new `path` method, alongside comprehensive documentation and tests. The most significant changes include the implementation of the `path` method in the core classes, updates to the documentation, and the addition of feature tests to ensure correct behavior across various scenarios.

**New Feature: Path Retrieval**
- Added a `path` method to both `RetrieveAttachment` and `AttachmentProxy` classes, allowing retrieval of the local filesystem path for an attachment or its specific style. This enables server-side processing workflows that require direct file access. [[1]](diffhunk://#diff-a9405a1fc2d26dfcf705bf3918dbf1b8e161cafbf9d8864456367b578b7ee9d0R83-R97) [[2]](diffhunk://#diff-d7d4d31a72c2a4edf03be9c802860b5814a67d5eb72bfd265513c83de364ac56R48-R52)

**Documentation**
- Added a new documentation page, `path.md`, explaining how to use the `path` method, including usage examples and guidance on when to use `path()` versus `url()`.
- Updated the documentation summary (`SUMMARY.md`) to include the new Path documentation.

**Testing**
- Introduced a new feature test suite (`PathTest.php`) that covers various scenarios for the `path` method, including original and styled files, non-existent styles, secure IDs, and non-local storage drivers.
- Updated the `MagicPropertiesTest` to include `path` in the list of available attachment methods.