### PR TITLE
Media Details Extraction On Queue

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,10 +69,10 @@ jobs:
 
       - name: Install ImageMagick
         run: |
-          curl -o /tmp/ImageMagick.tar.xz -sL https://imagemagick.org/archive/releases/ImageMagick-${{ matrix.imagemagick }}.tar.xz
+          curl -o /tmp/ImageMagick.tar.xz -sL https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{ matrix.imagemagick }}.tar.gz
           (
             cd /tmp || exit 1
-            tar xf ImageMagick.tar.xz
+            tar xf ImageMagick.tar.gz
             cd ImageMagick-${{ matrix.imagemagick }}
             sudo ./configure --prefix=/home/runner/im/imagemagick-${{ matrix.imagemagick }}
             sudo make -j$(nproc)

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install ImageMagick
         run: |
-          curl -o /tmp/ImageMagick.tar.xz -sL https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{ matrix.imagemagick }}.tar.gz
+          curl -o /tmp/ImageMagick.tar.gz -sL https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{ matrix.imagemagick }}.tar.gz
           (
             cd /tmp || exit 1
             tar xf ImageMagick.tar.gz

--- a/config/config.php
+++ b/config/config.php
@@ -221,6 +221,9 @@ return [
     | asynchronously via a queue.
     | When false, details are extracted synchronously during the request.
     |
+    | Note: this feature only works in ORM mode. Media details for standalone uploads
+    | will be extracted synchronously during the request.
+    |
     */
 
     'extract-media-details-on-queue' => env('LARUPLOAD_EXTRACT_MEDIA_DETAILS_ON_QUEUE', false),

--- a/config/config.php
+++ b/config/config.php
@@ -212,6 +212,19 @@ return [
 
     'preserve-files' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Fetch Media Details on Queue
+    |--------------------------------------------------------------------------
+    |
+    | When true, Larupload will fetch media details (like duration, resolution, etc.)
+    | asynchronously via a queue.
+    | When false, details are fetched synchronously during the request.
+    |
+    */
+
+    'fetch-media-details-on-queue' => env('LARUPLOAD_FETCH_MEDIA_DETAILS_ON_QUEUE', false),
+
     'ffmpeg' => [
         /*
         |--------------------------------------------------------------------------

--- a/config/config.php
+++ b/config/config.php
@@ -214,16 +214,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Fetch Media Details on Queue
+    | Extract Media Details on Queue
     |--------------------------------------------------------------------------
     |
-    | When true, Larupload will fetch media details (like duration, resolution, etc.)
+    | When true, Larupload will extract media details (like duration, resolution, etc.)
     | asynchronously via a queue.
-    | When false, details are fetched synchronously during the request.
+    | When false, details are extracted synchronously during the request.
     |
     */
 
-    'fetch-media-details-on-queue' => env('LARUPLOAD_FETCH_MEDIA_DETAILS_ON_QUEUE', false),
+    'extract-media-details-on-queue' => env('LARUPLOAD_EXTRACT_MEDIA_DETAILS_ON_QUEUE', false),
 
     'ffmpeg' => [
         /*

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
   * [Dominant Color Quality](advanced-usage/configuration/dominant-color-quality.md)
   * [Keep Old Files](advanced-usage/configuration/keep-old-files.md)
   * [Preserve Files](advanced-usage/configuration/preserve-files.md)
+  * [Extract Media Details On Queue](advanced-usage/configuration/extract-media-details-on-queue.md)
   * [Store Original File Name](advanced-usage/configuration/store-original-file-name.md)
   * [Optimize Image](advanced-usage/configuration/optimize-image.md)
   * [FFMpeg](advanced-usage/configuration/ffmpeg/README.md)
@@ -56,6 +57,7 @@
   * [Dominant Color Quality](advanced-usage/attachment/dominant-color-quality.md)
   * [Keep Old Files](advanced-usage/attachment/keep-old-files.md)
   * [Preserve Files](advanced-usage/attachment/preserve-files.md)
+  * [Extract Media Details On Queue](advanced-usage/attachment/extract-media-details-on-queue.md)
   * [Store Original File Name](advanced-usage/attachment/store-original-file-name.md)
   * [SecureIds Method](advanced-usage/attachment/secureids-method.md)
   * [Optimize Image](advanced-usage/attachment/optimize-image.md)
@@ -89,6 +91,9 @@
 * [Queue FFMpeg Processes](queue-ffmpeg-processes/README.md)
   * [Job Completion Event](queue-ffmpeg-processes/job-completion-event.md)
   * [FFMpeg Queue Relationships](queue-ffmpeg-processes/ffmpeg-queue-relationships.md)
+* [Queue Media Details Extraction](queue-ffmpeg-processes-1/README.md)
+  * [Job Completion Event](queue-ffmpeg-processes-1/job-completion-event.md)
+  * [Media Details Extraction Queue Relationships](queue-ffmpeg-processes-1/ffmpeg-queue-relationships.md)
 
 ## 🧱 Standalone Uploader
 

--- a/docs/advanced-usage/attachment/extract-media-details-on-queue.md
+++ b/docs/advanced-usage/attachment/extract-media-details-on-queue.md
@@ -1,0 +1,39 @@
+# Extract Media Details On Queue
+
+The `extractMediaDetailsOnQueue` method determines whether Larupload should extract media details asynchronously using Laravel's queue system.
+
+When enabled, Larupload dispatches a queued job to extract media details such as <mark style="color:red;">duration</mark>, <mark style="color:red;">dimensions</mark>, and other available metadata after the upload process completes. This helps reduce request time, especially when working with large audio or video files.
+
+When disabled, media details are extracted synchronously during the upload request, ensuring the metadata is immediately available once the upload finishes.
+
+```php
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Traits\Larupload;
+
+class Media extends Model
+{
+    use Larupload;
+
+    public function attachments(): array
+    {
+        return [
+            Attachment::make('file')->extractMediaDetailsOnQueue(true)
+        ];
+    }
+}
+```
+
+
+
+{% hint style="info" %}
+Run a Laravel queue worker when this option is enabled. Media details remain unavailable until the job completes.
+{% endhint %}
+
+{% hint style="info" %}
+This feature only works in ORM mode! Media details for <mark style="color:$danger;">standalone</mark> uploads will be extracted synchronously during the request.
+{% endhint %}

--- a/docs/advanced-usage/configuration/extract-media-details-on-queue.md
+++ b/docs/advanced-usage/configuration/extract-media-details-on-queue.md
@@ -1,0 +1,19 @@
+---
+description: 'Default: false'
+---
+
+# Extract Media Details On Queue
+
+Set <mark style="color:red;">`extract-media-details-on-queue`</mark> to <mark style="color:red;">`true`</mark> to extract media details asynchronously.
+
+Larupload dispatches a queue job for details such as duration and resolution. This keeps the upload request responsive.
+
+Set it to `false` to extract details synchronously during the upload request.
+
+{% hint style="info" %}
+Run a Laravel queue worker when this option is enabled. Media details remain unavailable until the job completes.
+{% endhint %}
+
+{% hint style="info" %}
+This feature only works in ORM mode! Media details for <mark style="color:$danger;">standalone</mark> uploads will be extracted synchronously during the request.
+{% endhint %}

--- a/docs/queue-ffmpeg-processes-1/README.md
+++ b/docs/queue-ffmpeg-processes-1/README.md
@@ -1,0 +1,19 @@
+# Queue Media Details Extraction
+
+{% hint style="info" %}
+If you are reading this, we assume you know what is [Laravel Queue](https://laravel.com/docs/queues). if not, please read Laravel's documentation first.
+{% endhint %}
+
+Larupload can extract media details either **synchronously** during the upload request or **asynchronously** using Laravel's queue system.
+
+When media details extraction is queued, Larupload uploads the original file immediately and dispatches a background job to extract metadata such as <mark style="color:red;">duration</mark>, <mark style="color:red;">dimensions</mark>, and other available media information. This reduces the upload request time, especially when working with large audio and video files.
+
+If queueing is disabled, Larupload extracts the media details during the upload request, making them available immediately after the upload completes.
+
+To use queued extraction, ensure that your application's queue worker is running so the dispatched jobs can be processed promptly.
+
+
+
+{% hint style="info" %}
+This feature only works in ORM mode! Media details for <mark style="color:$danger;">standalone</mark> uploads will be extracted synchronously during the request.
+{% endhint %}

--- a/docs/queue-ffmpeg-processes-1/ffmpeg-queue-relationships.md
+++ b/docs/queue-ffmpeg-processes-1/ffmpeg-queue-relationships.md
@@ -1,0 +1,16 @@
+# Media Details Extraction Queue Relationships
+
+Larupload provides two relationships that allow you to monitor media details extraction queue processes and view the history of all extraction jobs.
+
+The <mark style="color:red;">`laruploadMediaDetailsQueue`</mark> relationship provides information about the currently running media details extraction job. The <mark style="color:red;">`laruploadMediaDetailsQueues`</mark> relationship provides a list of all media details extraction jobs, including their status, start and end times, and any errors that occurred during processing.
+
+These relationships are available on all Eloquent models using Larupload and provide a simple way to monitor media details extraction processes in your application.
+
+```php
+Upload::query()
+    ->where('id', 21)
+    ->with('laruploadMediaDetailsQueue', 'laruploadMediaDetailsQueues')
+    ->first();
+```
+
+<br>

--- a/docs/queue-ffmpeg-processes-1/job-completion-event.md
+++ b/docs/queue-ffmpeg-processes-1/job-completion-event.md
@@ -1,0 +1,67 @@
+# Job Completion Event
+
+Larupload dispatches the <mark style="color:red;">`LaruploadMediaDetailsQueueFinished`</mark> event after a queued media details extraction job has completed successfully.
+
+This event is useful when you need to perform follow-up actions once media metadata has been extracted, such as:
+
+* Updating related records
+* Dispatching additional jobs
+* Sending notifications
+* Synchronizing data with external services
+
+#### Event Payload
+
+The event exposes the following properties:
+
+| Property | Type   |
+| -------- | ------ |
+| id       | int    |
+| model    | string |
+| statusId | int    |
+
+
+
+
+
+1. **Create Listener**
+
+```bash
+php artisan make:listener LaruploadMediaDetailsQueueFinishedListener
+```
+
+2. **Register Listener**
+
+Laravel will automatically discover and register the listener as long as it is placed in your application's `Listeners` directory and the event is type-hinted in the `handle` method.
+
+If event discovery is disabled, you can register the listener manually using Laravel's event registration mechanism.
+
+{% code title="App\Providers\EventServiceProvider" %}
+```php
+use App\Events\OrderShipped;
+use Mostafaznv\Larupload\Events\LaruploadMediaDetailsQueueFinished;
+use App\Listeners\LaruploadMediaDetailsQueueFinishedListener;
+ 
+
+protected $listen = [
+    LaruploadMediaDetailsQueueFinished::class => [
+        LaruploadMediaDetailsQueueFinishedListener::class,
+    ],
+];
+```
+{% endcode %}
+
+3. **Listen**
+
+```php
+<?php
+
+namespace App\Listeners;
+
+class LaruploadMediaDetailsQueueFinishedListener
+{
+    public function handle(LaruploadMediaDetailsQueueFinished $event)
+    {
+        info("larupload media details extraction finished. id: $event->id, model: $event->model, statusId: $event->statusId");
+    }
+}
+```

--- a/migrations/2026_07_13_150317_create_details_queue_table.php
+++ b/migrations/2026_07_13_150317_create_details_queue_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Mostafaznv\Larupload\Larupload;
+
+
+class CreateDetailsQueueTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create(Larupload::DETAILS_QUEUE_TABLE, function(Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('record_id');
+            $table->string('record_class', 50);
+            $table->boolean('status')->default(0);
+            $table->text('message')->nullable();
+
+            $table->timestamp('created_at')->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(Larupload::FFMPEG_QUEUE_TABLE);
+    }
+}

--- a/src/Actions/Attachment/SaveAttachmentAction.php
+++ b/src/Actions/Attachment/SaveAttachmentAction.php
@@ -25,7 +25,7 @@ class SaveAttachmentAction extends StoreAttachmentAction
                 }
 
                 $this->basic();
-                $this->media();
+                $this->media($model);
                 $this->uploadOriginalFile($this->attachment->id);
                 $this->setCover($this->attachment->id);
             }

--- a/src/Actions/Attachment/SaveStandaloneAttachmentAction.php
+++ b/src/Actions/Attachment/SaveStandaloneAttachmentAction.php
@@ -16,7 +16,7 @@ class SaveStandaloneAttachmentAction extends StoreAttachmentAction
     {
         $this->clean();
         $this->basic();
-        $this->media();
+        $this->media(null);
         $this->uploadOriginalFile($this->attachment->id);
         $this->setCover($this->attachment->id);
 

--- a/src/Actions/Attachment/StoreAttachmentAction.php
+++ b/src/Actions/Attachment/StoreAttachmentAction.php
@@ -43,7 +43,7 @@ abstract class StoreAttachmentAction
 
     protected function media(?Model $model): void
     {
-        $extractOnQueue = config('larupload.extract-media-details-on-queue', false);
+        $extractOnQueue = $this->attachment->extractMediaDetailsOnQueue;
 
         if ($extractOnQueue and $model) {
             /**

--- a/src/Actions/Attachment/StoreAttachmentAction.php
+++ b/src/Actions/Attachment/StoreAttachmentAction.php
@@ -5,6 +5,7 @@ namespace Mostafaznv\Larupload\Actions\Attachment;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\Actions\Cover\SetCoverAction;
+use Mostafaznv\Larupload\Actions\Queue\InitializeMediaDetailsQueueAction;
 use Mostafaznv\Larupload\Actions\SetFileNameAction;
 use Mostafaznv\Larupload\DTOs\CoverActionData;
 use Mostafaznv\Larupload\Enums\LaruploadFileType;
@@ -40,30 +41,39 @@ abstract class StoreAttachmentAction
         $this->attachment->output->mimeType = $this->attachment->file->getMimeType();
     }
 
-    protected function media(): void
+    protected function media(?Model $model): void
     {
-        switch ($this->attachment->type) {
-            case LaruploadFileType::VIDEO:
-            case LaruploadFileType::AUDIO:
-                $meta = $this->ffmpeg()->getMeta();
+        $fetchOnQueue = config('larupload.fetch-media-details-on-queue', false);
 
-                $this->attachment->output->width = $meta->width;
-                $this->attachment->output->height = $meta->height;
-                $this->attachment->output->duration = $meta->duration;
+        if ($fetchOnQueue and $model) {
+            resolve(InitializeMediaDetailsQueueAction::class)(
+                $this->attachment, $model->id, $model->getMorphClass()
+            );
+        }
+        else {
+            switch ($this->attachment->type) {
+                case LaruploadFileType::VIDEO:
+                case LaruploadFileType::AUDIO:
+                    $meta = $this->ffmpeg()->getMeta();
 
-                break;
+                    $this->attachment->output->width = $meta->width;
+                    $this->attachment->output->height = $meta->height;
+                    $this->attachment->output->duration = $meta->duration;
 
-            case LaruploadFileType::IMAGE:
-                $img = $this->img($this->attachment->file);
-                $meta = $img->getMeta();
+                    break;
 
-                $this->attachment->output->width = $meta->width;
-                $this->attachment->output->height = $meta->height;
-                $this->attachment->output->dominantColor = $this->attachment->dominantColor
-                    ? $img->getDominantColor()
-                    : null;
+                case LaruploadFileType::IMAGE:
+                    $img = $this->img($this->attachment->file);
+                    $meta = $img->getMeta();
 
-                break;
+                    $this->attachment->output->width = $meta->width;
+                    $this->attachment->output->height = $meta->height;
+                    $this->attachment->output->dominantColor = $this->attachment->dominantColor
+                        ? $img->getDominantColor()
+                        : null;
+
+                    break;
+            }
         }
     }
 

--- a/src/Actions/Attachment/StoreAttachmentAction.php
+++ b/src/Actions/Attachment/StoreAttachmentAction.php
@@ -5,8 +5,8 @@ namespace Mostafaznv\Larupload\Actions\Attachment;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\Actions\Cover\SetCoverAction;
-use Mostafaznv\Larupload\Actions\Queue\InitializeMediaDetailsQueueAction;
 use Mostafaznv\Larupload\Actions\SetFileNameAction;
+use Mostafaznv\Larupload\Concerns\LaruploadObservers;
 use Mostafaznv\Larupload\DTOs\CoverActionData;
 use Mostafaznv\Larupload\Enums\LaruploadFileType;
 use Mostafaznv\Larupload\Larupload;
@@ -46,34 +46,37 @@ abstract class StoreAttachmentAction
         $fetchOnQueue = config('larupload.fetch-media-details-on-queue', false);
 
         if ($fetchOnQueue and $model) {
-            resolve(InitializeMediaDetailsQueueAction::class)(
-                $this->attachment, $model->id, $model->getMorphClass()
-            );
+            /**
+             * Do nothing, it will be processed after saving the model
+             * @see LaruploadObservers
+             * @see DispatchModelMediaDetailsExtractionAction
+             */
+
+            return;
         }
-        else {
-            switch ($this->attachment->type) {
-                case LaruploadFileType::VIDEO:
-                case LaruploadFileType::AUDIO:
-                    $meta = $this->ffmpeg()->getMeta();
 
-                    $this->attachment->output->width = $meta->width;
-                    $this->attachment->output->height = $meta->height;
-                    $this->attachment->output->duration = $meta->duration;
+        switch ($this->attachment->type) {
+            case LaruploadFileType::VIDEO:
+            case LaruploadFileType::AUDIO:
+                $meta = $this->ffmpeg()->getMeta();
 
-                    break;
+                $this->attachment->output->width = $meta->width;
+                $this->attachment->output->height = $meta->height;
+                $this->attachment->output->duration = $meta->duration;
 
-                case LaruploadFileType::IMAGE:
-                    $img = $this->img($this->attachment->file);
-                    $meta = $img->getMeta();
+                break;
 
-                    $this->attachment->output->width = $meta->width;
-                    $this->attachment->output->height = $meta->height;
-                    $this->attachment->output->dominantColor = $this->attachment->dominantColor
-                        ? $img->getDominantColor()
-                        : null;
+            case LaruploadFileType::IMAGE:
+                $img = $this->img($this->attachment->file);
+                $meta = $img->getMeta();
 
-                    break;
-            }
+                $this->attachment->output->width = $meta->width;
+                $this->attachment->output->height = $meta->height;
+                $this->attachment->output->dominantColor = $this->attachment->dominantColor
+                    ? $img->getDominantColor()
+                    : null;
+
+                break;
         }
     }
 

--- a/src/Actions/Attachment/StoreAttachmentAction.php
+++ b/src/Actions/Attachment/StoreAttachmentAction.php
@@ -43,9 +43,9 @@ abstract class StoreAttachmentAction
 
     protected function media(?Model $model): void
     {
-        $fetchOnQueue = config('larupload.fetch-media-details-on-queue', false);
+        $extractOnQueue = config('larupload.extract-media-details-on-queue', false);
 
-        if ($fetchOnQueue and $model) {
+        if ($extractOnQueue and $model) {
             /**
              * Do nothing, it will be processed after saving the model
              * @see LaruploadObservers

--- a/src/Actions/DispatchModelMediaDetailsExtractionAction.php
+++ b/src/Actions/DispatchModelMediaDetailsExtractionAction.php
@@ -15,16 +15,12 @@ class DispatchModelMediaDetailsExtractionAction
      */
     public function __invoke(Model $model, array $attachments): void
     {
-        $extractOnQueue = config('larupload.extract-media-details-on-queue', false);
-
-        if ($extractOnQueue === false) {
-            return;
-        }
-
         foreach ($attachments as $attachment) {
-            resolve(InitializeMediaDetailsQueueAction::class)(
-                $attachment, $model->id, $model->getMorphClass()
-            );
+            if ($attachment->extractMediaDetailsOnQueue) {
+                resolve(InitializeMediaDetailsQueueAction::class)(
+                    $attachment, $model->id, $model->getMorphClass()
+                );
+            }
         }
     }
 }

--- a/src/Actions/DispatchModelMediaDetailsExtractionAction.php
+++ b/src/Actions/DispatchModelMediaDetailsExtractionAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mostafaznv\Larupload\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Mostafaznv\Larupload\Actions\Queue\InitializeMediaDetailsQueueAction;
+use Mostafaznv\Larupload\Storage\Attachment;
+
+
+class DispatchModelMediaDetailsExtractionAction
+{
+    /**
+     * @param Model $model
+     * @param Attachment[] $attachments
+     */
+    public function __invoke(Model $model, array $attachments): void
+    {
+        $fetchOnQueue = config('larupload.fetch-media-details-on-queue', false);
+
+        if ($fetchOnQueue === false) {
+            return;
+        }
+
+        foreach ($attachments as $attachment) {
+            resolve(InitializeMediaDetailsQueueAction::class)(
+                $attachment, $model->id, $model->getMorphClass()
+            );
+        }
+    }
+}

--- a/src/Actions/DispatchModelMediaDetailsExtractionAction.php
+++ b/src/Actions/DispatchModelMediaDetailsExtractionAction.php
@@ -15,9 +15,9 @@ class DispatchModelMediaDetailsExtractionAction
      */
     public function __invoke(Model $model, array $attachments): void
     {
-        $fetchOnQueue = config('larupload.fetch-media-details-on-queue', false);
+        $extractOnQueue = config('larupload.extract-media-details-on-queue', false);
 
-        if ($fetchOnQueue === false) {
+        if ($extractOnQueue === false) {
             return;
         }
 

--- a/src/Actions/Queue/HandleFFMpegQueueAction.php
+++ b/src/Actions/Queue/HandleFFMpegQueueAction.php
@@ -29,9 +29,7 @@ class HandleFFMpegQueueAction
 
 
         if ($this->shouldDeleteLocalDirectory($attachment, $isLastOne)) {
-            Storage::disk($attachment->localDisk)->deleteDirectory(
-                $standalone ? "$attachment->folder/$attachment->nameKebab" : "$attachment->folder/$attachment->id"
-            );
+            delete_local_copy($attachment, $standalone);
         }
     }
 

--- a/src/Actions/Queue/HandleMediaDetailsQueueAction.php
+++ b/src/Actions/Queue/HandleMediaDetailsQueueAction.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Mostafaznv\Larupload\Actions\Queue;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Mostafaznv\Larupload\Enums\LaruploadFileType;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Storage\FFMpeg\FFMpeg;
+use Mostafaznv\Larupload\Storage\Image;
+
+
+class HandleMediaDetailsQueueAction
+{
+    public function execute(Model $model, Attachment $attachment): void
+    {
+        $attachment->file = $this->file($attachment);
+
+
+        switch ($attachment->meta('type')) {
+            case LaruploadFileType::VIDEO:
+            case LaruploadFileType::AUDIO:
+                $meta = $this->ffmpeg($attachment)->getMeta();
+
+                $attachment->output->width = $meta->width;
+                $attachment->output->height = $meta->height;
+                $attachment->output->duration = $meta->duration;
+
+
+                $model = $attachment->output->save($model, $attachment->name, $attachment->mode);
+                $model->saveQuietly();
+
+                break;
+
+            case LaruploadFileType::IMAGE:
+                $img = $this->img($attachment);
+                $meta = $img->getMeta();
+
+                $attachment->output->width = $meta->width;
+                $attachment->output->height = $meta->height;
+                $attachment->output->dominantColor = null;
+
+                if ($attachment->dominantColor) {
+                    $attachment->output->dominantColor = $img->getDominantColor();
+                }
+
+                $model = $attachment->output->save($model, $attachment->name, $attachment->mode);
+                $model->saveQuietly();
+
+                break;
+        }
+
+
+        delete_local_copy($attachment);
+    }
+
+
+    private function file(Attachment $attachment): UploadedFile
+    {
+        $basePath = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+        $path = $basePath . '/' . $attachment->output->name;
+        $disk = disk_driver_is_local($attachment->disk) ? $attachment->disk : $attachment->localDisk;
+
+        $path = Storage::disk($disk)->path($path);
+
+        return new UploadedFile($path, $attachment->output->name, null, null, true);
+    }
+
+    private function ffmpeg(Attachment $attachment): FFMpeg
+    {
+        return new FFMpeg($attachment->file, $attachment->disk, $attachment->dominantColorQuality);
+    }
+
+    private function img(Attachment $attachment): Image
+    {
+        return new Image(
+            file: $attachment->file,
+            disk: $attachment->disk,
+            library: $attachment->imageProcessingLibrary,
+            dominantColorQuality: $attachment->dominantColorQuality
+        );
+    }
+}

--- a/src/Actions/Queue/InitializeFFMpegQueueAction.php
+++ b/src/Actions/Queue/InitializeFFMpegQueueAction.php
@@ -3,7 +3,6 @@
 namespace Mostafaznv\Larupload\Actions\Queue;
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\Exceptions\FFMpegQueueMaxNumExceededException;
 use Mostafaznv\Larupload\Jobs\ProcessFFMpeg;
 use Mostafaznv\Larupload\Larupload;

--- a/src/Actions/Queue/InitializeFFMpegQueueAction.php
+++ b/src/Actions/Queue/InitializeFFMpegQueueAction.php
@@ -34,11 +34,7 @@ class InitializeFFMpegQueueAction
 
         if ($flag) {
             // save a copy of the original file to use it on process ffmpeg queue, then delete it
-            if (!disk_driver_is_local($attachment->disk)) {
-                $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
-
-                Storage::disk($attachment->localDisk)->putFileAs($path, $attachment->file, $attachment->output->name);
-            }
+            local_copy($attachment);
 
             $queueId = DB::table(Larupload::FFMPEG_QUEUE_TABLE)->insertGetId([
                 'record_id'    => $id,

--- a/src/Actions/Queue/InitializeMediaDetailsQueueAction.php
+++ b/src/Actions/Queue/InitializeMediaDetailsQueueAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Mostafaznv\Larupload\Actions\Queue;
+
+use Illuminate\Support\Facades\DB;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Storage\Attachment;
+
+
+class InitializeMediaDetailsQueueAction
+{
+    public function __invoke(Attachment $attachment, int $id, string $class): void
+    {
+        // save a copy of the original file to extract media details from when storage is remote, then delete it.
+        local_copy($attachment);
+
+        $queueId = DB::table(Larupload::DETAILS_QUEUE_TABLE)->insertGetId([
+            'record_id'    => $id,
+            'record_class' => $class,
+            'created_at'   => now(),
+        ]);
+
+
+        ProcessMediaDetails::dispatch($queueId, $id, $attachment->name, $class);
+    }
+}

--- a/src/Concerns/LaruploadObservers.php
+++ b/src/Concerns/LaruploadObservers.php
@@ -5,6 +5,7 @@ namespace Mostafaznv\Larupload\Concerns;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\Actions\Attachment\SaveAttachmentAction;
+use Mostafaznv\Larupload\Actions\DispatchModelMediaDetailsExtractionAction;
 use Mostafaznv\Larupload\Actions\HandleModelStylesAction;
 use Mostafaznv\Larupload\Events\LaruploadProcessFinished;
 
@@ -29,6 +30,7 @@ trait LaruploadObservers
             if ($shouldSave) {
                 $model->save();
 
+                resolve(DispatchModelMediaDetailsExtractionAction::class)($model, $model->attachments);
                 resolve(HandleModelStylesAction::class)($model, $model->attachments);
 
                 event(

--- a/src/Concerns/LaruploadRelations.php
+++ b/src/Concerns/LaruploadRelations.php
@@ -5,6 +5,7 @@ namespace Mostafaznv\Larupload\Concerns;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Mostafaznv\Larupload\Models\LaruploadFFMpegQueue;
+use Mostafaznv\Larupload\Models\LaruploadMediaDetailsQueue;
 
 
 trait LaruploadRelations
@@ -29,6 +30,31 @@ trait LaruploadRelations
     public function laruploadQueues(): HasMany
     {
         return $this->hasMany(LaruploadFFMpegQueue::class, 'record_id')
+            ->where('record_class', self::class)
+            ->orderByDesc('id');
+    }
+
+
+    /**
+     * Retrieve latest status log for media details queue process
+     *
+     * @return HasOne
+     */
+    public function laruploadMediaDetailsQueue(): HasOne
+    {
+        return $this->hasOne(LaruploadMediaDetailsQueue::class, 'record_id')
+            ->where('record_class', self::class)
+            ->orderByDesc('id');
+    }
+
+    /**
+     * Retrieve all status logs for media details queue process
+     *
+     * @return HasMany
+     */
+    public function laruploadMediaDetailsQueues(): HasMany
+    {
+        return $this->hasMany(LaruploadMediaDetailsQueue::class, 'record_id')
             ->where('record_class', self::class)
             ->orderByDesc('id');
     }

--- a/src/Events/LaruploadMediaDetailsQueueFinished.php
+++ b/src/Events/LaruploadMediaDetailsQueueFinished.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mostafaznv\Larupload\Events;
+
+use Illuminate\Queue\SerializesModels;
+
+
+class LaruploadMediaDetailsQueueFinished
+{
+    use SerializesModels;
+
+    public int    $id;
+    public string $model;
+    public int    $statusId;
+
+
+    public function __construct(int $id, string $model, int $statusId)
+    {
+        $this->id = $id;
+        $this->model = $model;
+        $this->statusId = $statusId;
+    }
+}

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -235,4 +235,32 @@ if (!function_exists('larupload_relative_path')) {
     }
 }
 
+if (!function_exists('local_copy')) {
+    /**
+     * Create a local copy of the attachment file for remote disks.
+     *
+     * @param \Mostafaznv\Larupload\Storage\Attachment $attachment
+     * @return ?string
+     */
+    function local_copy(\Mostafaznv\Larupload\Storage\Attachment $attachment): ?string
+    {
+        if (disk_driver_is_local($attachment->disk)) {
+            return null;
+        }
 
+
+        $storage = \Illuminate\Support\Facades\Storage::disk($attachment->localDisk);
+        $path = larupload_relative_path($attachment, $attachment->id, \Mostafaznv\Larupload\Larupload::ORIGINAL_FOLDER);
+        $fullPath = "$path/{$attachment->output->name}";
+        $md5 = md5_file($attachment->file->getRealPath());
+
+        if ($storage->exists($fullPath)) {
+            return $md5;
+        }
+
+
+        $res = $storage->putFileAs($path, $attachment->file, $attachment->output->name);
+
+        return $res ? $md5 : null;
+    }
+}

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -240,27 +240,41 @@ if (!function_exists('local_copy')) {
      * Create a local copy of the attachment file for remote disks.
      *
      * @param \Mostafaznv\Larupload\Storage\Attachment $attachment
-     * @return ?string
+     * @return bool
      */
-    function local_copy(\Mostafaznv\Larupload\Storage\Attachment $attachment): ?string
+    function local_copy(\Mostafaznv\Larupload\Storage\Attachment $attachment): bool
     {
         if (disk_driver_is_local($attachment->disk)) {
-            return null;
+            return false;
         }
 
 
         $storage = \Illuminate\Support\Facades\Storage::disk($attachment->localDisk);
         $path = larupload_relative_path($attachment, $attachment->id, \Mostafaznv\Larupload\Larupload::ORIGINAL_FOLDER);
         $fullPath = "$path/{$attachment->output->name}";
-        $md5 = md5_file($attachment->file->getRealPath());
 
-        if ($storage->exists($fullPath)) {
-            return $md5;
-        }
+        $md5 = md5("$attachment->localDisk/$fullPath");
+        $cacheKey = "larupload:$md5";
+        $lockKey = "lock:$cacheKey";
 
 
-        $res = $storage->putFileAs($path, $attachment->file, $attachment->output->name);
 
-        return $res ? $md5 : null;
+        return \Illuminate\Support\Facades\Cache::lock($lockKey, 60)->block(5, function () use ($storage, $path, $fullPath, $attachment, $cacheKey) {
+            if ($storage->exists($fullPath)) {
+                \Illuminate\Support\Facades\Cache::increment($cacheKey);
+
+                return true;
+            }
+
+            $res = $storage->putFileAs($path, $attachment->file, $attachment->output->name);
+
+            if ($res) {
+                \Illuminate\Support\Facades\Cache::increment($cacheKey);
+
+                return true;
+            }
+
+            return false;
+        });
     }
 }

--- a/src/Helpers/Utils.php
+++ b/src/Helpers/Utils.php
@@ -258,7 +258,6 @@ if (!function_exists('local_copy')) {
         $lockKey = "lock:$cacheKey";
 
 
-
         return \Illuminate\Support\Facades\Cache::lock($lockKey, 60)->block(5, function () use ($storage, $path, $fullPath, $attachment, $cacheKey) {
             if ($storage->exists($fullPath)) {
                 \Illuminate\Support\Facades\Cache::increment($cacheKey);
@@ -273,6 +272,54 @@ if (!function_exists('local_copy')) {
 
                 return true;
             }
+
+            return false;
+        });
+    }
+}
+
+if (!function_exists('delete_local_copy')) {
+    /**
+     * Delete the local cached copy of an attachment for remote disks when it is no longer needed.
+     *
+     * @param \Mostafaznv\Larupload\Storage\Attachment $attachment
+     * @param bool $standalone
+     * @return bool
+     */
+    function delete_local_copy(\Mostafaznv\Larupload\Storage\Attachment $attachment, bool $standalone = false): bool
+    {
+        if (disk_driver_is_local($attachment->disk)) {
+            return false;
+        }
+
+
+        $path = larupload_relative_path($attachment, $attachment->id, \Mostafaznv\Larupload\Larupload::ORIGINAL_FOLDER);
+        $fullPath = "$path/{$attachment->output->name}";
+
+        $md5 = md5("$attachment->localDisk/$fullPath");
+        $cacheKey = "larupload:$md5";
+        $lockKey = "lock:$cacheKey";
+
+
+        return \Illuminate\Support\Facades\Cache::lock($lockKey, 60)->block(5, function () use ($attachment, $standalone, $cacheKey): bool {
+            $value = \Illuminate\Support\Facades\Cache::get($cacheKey);
+
+            if ($value === null) {
+                return false;
+            }
+
+            if ($value <= 1) {
+                \Illuminate\Support\Facades\Cache::forget($cacheKey);
+
+                \Illuminate\Support\Facades\Storage::disk($attachment->localDisk)->deleteDirectory(
+                    $standalone ? "$attachment->folder/$attachment->nameKebab" : "$attachment->folder/$attachment->id"
+                );
+
+                return true;
+            }
+
+
+            \Illuminate\Support\Facades\Cache::decrement($cacheKey);
 
             return false;
         });

--- a/src/Jobs/ProcessMediaDetails.php
+++ b/src/Jobs/ProcessMediaDetails.php
@@ -69,11 +69,6 @@ class ProcessMediaDetails implements ShouldQueue
         }
     }
 
-    public function getId(): int
-    {
-        return $this->id;
-    }
-
     /**
      * Update DETAILS_QUEUE_TABLE table
      *

--- a/src/Jobs/ProcessMediaDetails.php
+++ b/src/Jobs/ProcessMediaDetails.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Mostafaznv\Larupload\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\DB;
+use Mostafaznv\Larupload\Events\LaruploadMediaDetailsQueueFinished;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Storage\Proxy\AttachmentProxy;
+
+
+class ProcessMediaDetails implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected int    $queueId;
+    protected int    $id;
+    protected string $name;
+    protected string $model;
+
+
+    public function __construct(int $queueId, int $id, string $name, string $model)
+    {
+        $this->queueId = $queueId;
+        $this->id = $id;
+        $this->name = $name;
+        $this->model = $model;
+
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function handle(): void
+    {
+        $this->updateStatus(false, true);
+
+
+        try {
+            /** @var Model $class */
+            $class = class_exists($this->model) ? $this->model : Relation::getMorphedModel($this->model);
+            $model = $class::query()->where('id', $this->id)->first();
+
+            /** @var AttachmentProxy|null $attachment */
+            $attachment = $model?->{$this->name} ?? null;
+
+            if ($attachment) {
+                $attachment->handleMediaDetailsQueue($model);
+            }
+            else {
+                throw new FileNotFoundException('Unable to process media details: the model or attached file could not be found.');
+            }
+
+            $this->updateStatus(true, false);
+        }
+        catch (Exception $e) {
+            $this->updateStatus(false, false, $e->getMessage());
+
+            throw new Exception($e->getMessage());
+        }
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * Update DETAILS_QUEUE_TABLE table
+     *
+     * @param bool $status
+     * @param bool $isStarted
+     * @param string|null $message
+     * @return int
+     */
+    protected function updateStatus(bool $status, bool $isStarted, ?string $message = null): int
+    {
+        $dateColumn = $isStarted ? 'started_at' : 'finished_at';
+
+        $result = DB::table(Larupload::DETAILS_QUEUE_TABLE)->where('id', $this->queueId)->update([
+            'status'    => $status,
+            'message'   => $message,
+            $dateColumn => now(),
+        ]);
+
+        if ($result and $status) {
+            event(new LaruploadMediaDetailsQueueFinished($this->id, $this->model, $this->queueId));
+        }
+
+        return $result;
+    }
+}

--- a/src/Jobs/ProcessMediaDetails.php
+++ b/src/Jobs/ProcessMediaDetails.php
@@ -51,7 +51,7 @@ class ProcessMediaDetails implements ShouldQueue
             $model = $class::query()->where('id', $this->id)->first();
 
             /** @var AttachmentProxy|null $attachment */
-            $attachment = $model?->{$this->name} ?? null;
+            $attachment = $model?->attachment($this->name) ?? null;
 
             if ($attachment) {
                 $attachment->handleMediaDetailsQueue($model);

--- a/src/Larupload.php
+++ b/src/Larupload.php
@@ -16,8 +16,9 @@ class Larupload extends Attachment
     public const string COVER_FOLDER    = 'cover';
     public const string STREAM_FOLDER   = 'stream';
 
-    public const string LOCAL_DRIVER       = 'local';
-    public const string FFMPEG_QUEUE_TABLE = 'larupload_ffmpeg_queue';
+    public const string LOCAL_DRIVER        = 'local';
+    public const string FFMPEG_QUEUE_TABLE  = 'larupload_ffmpeg_queue';
+    public const string DETAILS_QUEUE_TABLE = 'larupload_details_queue';
 
 
     use BootStandaloneLarupload;

--- a/src/Models/LaruploadMediaDetailsQueue.php
+++ b/src/Models/LaruploadMediaDetailsQueue.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Mostafaznv\Larupload\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mostafaznv\Larupload\Larupload;
+
+
+class LaruploadMediaDetailsQueue extends Model
+{
+    protected $table = Larupload::DETAILS_QUEUE_TABLE;
+}

--- a/src/Storage/Proxy/AttachmentProxy.php
+++ b/src/Storage/Proxy/AttachmentProxy.php
@@ -2,8 +2,10 @@
 
 namespace Mostafaznv\Larupload\Storage\Proxy;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Mostafaznv\Larupload\Actions\Queue\HandleFFMpegQueueAction;
+use Mostafaznv\Larupload\Actions\Queue\HandleMediaDetailsQueueAction;
 use Mostafaznv\Larupload\Larupload;
 use Illuminate\Http\RedirectResponse;
 use Mostafaznv\Larupload\Storage\Attachment;
@@ -55,8 +57,19 @@ readonly class AttachmentProxy
         return $this->attachment->download($style);
     }
 
+    /**
+     * @internal
+     */
     public function handleFFMpegQueue(bool $isLastOne = false): void
     {
         resolve(HandleFFMpegQueueAction::class)->execute($this->attachment, $isLastOne);
+    }
+
+    /**
+     * @internal
+     */
+    public function handleMediaDetailsQueue(Model $model): void
+    {
+        resolve(HandleMediaDetailsQueueAction::class)->execute($model, $this->attachment);
     }
 }

--- a/src/UploadEntities.php
+++ b/src/UploadEntities.php
@@ -69,6 +69,7 @@ class UploadEntities
 
     public bool $keepOldFiles;
     public bool $preserveFiles;
+    public bool $extractMediaDetailsOnQueue;
 
     public array $imageStyles = [];
     public array $videoStyles = [];
@@ -115,6 +116,7 @@ class UploadEntities
         $this->dominantColorQuality = $config['dominant-color-quality'];
         $this->keepOldFiles = $config['keep-old-files'];
         $this->preserveFiles = $config['preserve-files'];
+        $this->extractMediaDetailsOnQueue = $config['extract-media-details-on-queue'];
         $this->optimizeImage = $config['optimize-image']['enable'] ?? false;
         $this->ffmpegQueue = $config['ffmpeg']['queue'];
         $this->ffmpegMaxQueueNum = $config['ffmpeg']['max-queue-num'];
@@ -225,6 +227,13 @@ class UploadEntities
     public function preserveFiles(bool $status): self
     {
         $this->preserveFiles = $status;
+
+        return $this;
+    }
+
+    public function extractMediaDetailsOnQueue(bool $status): self
+    {
+        $this->extractMediaDetailsOnQueue = $status;
 
         return $this;
     }

--- a/tests/Feature/MagicPropertiesTest.php
+++ b/tests/Feature/MagicPropertiesTest.php
@@ -30,6 +30,7 @@ it('will return attachment on retrieving attachment property', function(Laruploa
             'path',
             'download',
             'handleFFMpegQueue',
+            'handleMediaDetailsQueue',
         ]);
 
 })->with('models');

--- a/tests/Feature/MediaDetailsQueueTest.php
+++ b/tests/Feature/MediaDetailsQueueTest.php
@@ -1,24 +1,17 @@
 <?php
 
-use FFMpeg\Format\Audio\Wav;
-use FFMpeg\Format\Video\X264;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Bus;
 use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
-use Mostafaznv\Larupload\Events\LaruploadFFMpegQueueFinished;
 use Mostafaznv\Larupload\Events\LaruploadMediaDetailsQueueFinished;
-use Mostafaznv\Larupload\Exceptions\FFMpegQueueMaxNumExceededException;
-use Mostafaznv\Larupload\Jobs\ProcessFFMpeg;
 use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
 use Mostafaznv\Larupload\Larupload;
-use Mostafaznv\Larupload\Models\LaruploadFFMpegQueue;
 use Mostafaznv\Larupload\Models\LaruploadMediaDetailsQueue;
 use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
 use Mostafaznv\Larupload\Test\Support\LaruploadTestConsts;
-use Mostafaznv\Larupload\Test\Support\Models\LaruploadQueueTestModel;
 
 
 beforeEach(function () {

--- a/tests/Feature/MediaDetailsQueueTest.php
+++ b/tests/Feature/MediaDetailsQueueTest.php
@@ -31,7 +31,7 @@ beforeEach(function () {
 
     Event::fake(LaruploadMediaDetailsQueueFinished::class);
 
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
 });
 
 

--- a/tests/Feature/MediaDetailsQueueTest.php
+++ b/tests/Feature/MediaDetailsQueueTest.php
@@ -1,0 +1,272 @@
+<?php
+
+use FFMpeg\Format\Audio\Wav;
+use FFMpeg\Format\Video\X264;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Bus;
+use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
+use Mostafaznv\Larupload\Events\LaruploadFFMpegQueueFinished;
+use Mostafaznv\Larupload\Events\LaruploadMediaDetailsQueueFinished;
+use Mostafaznv\Larupload\Exceptions\FFMpegQueueMaxNumExceededException;
+use Mostafaznv\Larupload\Jobs\ProcessFFMpeg;
+use Illuminate\Support\Facades\Storage;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Models\LaruploadFFMpegQueue;
+use Mostafaznv\Larupload\Models\LaruploadMediaDetailsQueue;
+use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
+use Mostafaznv\Larupload\Test\Support\LaruploadTestConsts;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadQueueTestModel;
+
+
+beforeEach(function () {
+    Storage::fake('public');
+    Storage::fake('local');
+    Storage::fake('s3');
+
+    Bus::fake();
+    Queue::fake();
+
+    Event::fake(LaruploadMediaDetailsQueueFinished::class);
+
+    config()->set('larupload.fetch-media-details-on-queue', true);
+});
+
+
+it('can extract media details on queue', function (UploadedFile $file) {
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+    save(LaruploadTestModels::QUEUE->instance(), $file);
+
+    Bus::assertDispatched(ProcessMediaDetails::class);
+
+})->with([
+    'mp4' => fn() => mp4(),
+    'mp3' => fn() => mp3(),
+    'jpg' => fn() => jpg(),
+]);
+
+it('wont extract media details on queue in standalone mode', function (UploadedFile $file) {
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+    Larupload::init('uploader')->upload($file);
+
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+})->with([
+    'mp4' => fn() => mp4(),
+    'mp3' => fn() => mp3(),
+    'jpg' => fn() => jpg(),
+]);
+
+it('stores data into database after calculating media details on queue', function () {
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model = save($model, jpg());
+
+    # test 1
+    $model = $model->fresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->height)
+        ->toBeNull();
+
+
+    # queue
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+    $job = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $job->handle();
+
+
+    # test 2
+    $model = $model->fresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->and($meta->height)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
+});
+
+it('queues extraction process for remote disks and deletes local files after finishing the process', function () {
+    # init
+    $disk = 's3';
+    $localDisk = config()->get('larupload.local-disk');
+
+    # save model
+    $model = LaruploadTestModels::REMOTE_QUEUE->instance();
+    $model = save($model, jpg());
+
+
+    # prepare for assertions
+    $fileName = $model->attachment('main_file')->meta('name');
+    $s3Files = Storage::disk($disk)->allFiles();
+    $localFiles = Storage::disk($localDisk)->allFiles();
+
+
+    $model = $model->fresh();
+    $meta = $model->attachment('main_file')->meta();
+
+
+    # test
+    expect($s3Files)
+        ->toHaveCount(2)
+        ->and($localFiles)
+        ->toHaveCount(1)
+        ->and($localFiles[0])
+        ->toEndWith($fileName)
+        ->and($meta->width)
+        ->toBeNull()
+        ->and($meta->height)
+        ->toBeNull();;
+
+
+    # queue
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+    $job = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $job->handle();
+
+
+    # test
+    $s3Files = Storage::disk($disk)->allFiles();
+    $localFiles = Storage::disk($localDisk)->allFiles();
+    $model = $model->fresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($s3Files)
+        ->toHaveCount(2)
+        ->and($localFiles)
+        ->toHaveCount(0)
+        ->and($meta->width)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->and($meta->height)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
+});
+
+it('can queue extraction process when using secure-ids', function () {
+    config()->set('larupload.secure-ids', LaruploadSecureIdsMethod::ULID);
+
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model = save($model, jpg());
+
+    # test 1
+    $model = $model->fresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->height)
+        ->toBeNull();
+
+
+    # queue
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+    $job = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $job->handle();
+
+
+    # test 2
+    $model = $model->fresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->and($meta->height)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
+});
+
+
+it('will change queue status after processing queue', function () {
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model = save($model, jpg());
+
+
+    # test 1
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+    expect($queue->status)->toBe(0);
+
+
+    # queue
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+    $job = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $job->handle();
+
+
+    # test 2
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue->status)->toBe(1);
+
+});
+
+it('will fire an event when process is finished', function () {
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model = save($model, jpg());
+
+
+    # test 1
+    Event::assertNotDispatched(LaruploadMediaDetailsQueueFinished::class);
+
+    # queue
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+    $job = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $job->handle();
+
+
+    # test 2
+    Event::assertDispatched(LaruploadMediaDetailsQueueFinished::class);
+
+});
+
+it('will update queue record with error message, when process failed', function () {
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model = save($model, jpg());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    # test 1
+    expect($queue->message)->toBeNull();
+
+
+    $path = Storage::disk('local')->path('/');
+    rmRf($path);
+
+
+    # queue
+    try {
+        $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+        $job = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+        $job->handle();
+
+        expect(true)->toBeFalse();
+    }
+    catch (Exception $e) {
+        $message = $e->getMessage();
+
+        expect($message)
+            ->toStartWith('The file')
+            ->toEndWith('does not exist');
+
+        $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+        expect($queue->message)->toBe($message);
+    }
+});
+
+it('can load queue relationships of model', function () {
+    $model = LaruploadTestModels::HEAVY->instance();
+    $model->load('laruploadMediaDetailsQueue', 'laruploadMediaDetailsQueues');
+    $model = save($model, jpg());
+
+    expect($model->laruploadMediaDetailsQueue)
+        ->toBeInstanceOf(LaruploadMediaDetailsQueue::class)
+        ->id->toBe(1)
+        ->status->toBe(0)
+        ->message->toBeNull()
+        ->and($model->laruploadMediaDetailsQueues)
+        ->toBeInstanceOf(Collection::class)
+        ->toHaveCount(1)
+        ->and($model->laruploadMediaDetailsQueues[0])
+        ->toBeInstanceOf(LaruploadMediaDetailsQueue::class);
+});

--- a/tests/Feature/ProcessMediaDetailsTest.php
+++ b/tests/Feature/ProcessMediaDetailsTest.php
@@ -24,7 +24,7 @@ beforeEach(function () {
     Storage::fake('public');
     Storage::fake('s3');
 
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
 });
 
 

--- a/tests/Feature/ProcessMediaDetailsTest.php
+++ b/tests/Feature/ProcessMediaDetailsTest.php
@@ -1,0 +1,279 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Mostafaznv\Larupload\Events\LaruploadMediaDetailsQueueFinished;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
+use Mostafaznv\Larupload\Test\Support\LaruploadTestConsts;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadHeavyTestModel;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadLightTestModel;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadQueueTestModel;
+
+
+beforeEach(function () {
+    Bus::fake();
+    Queue::fake();
+    Event::fake(LaruploadMediaDetailsQueueFinished::class);
+
+    Storage::fake('public');
+    Storage::fake('s3');
+
+    config()->set('larupload.fetch-media-details-on-queue', true);
+});
+
+
+it('will queue media details processing after saving a model', function (LaruploadHeavyTestModel|LaruploadLightTestModel $model, UploadedFile $file) {
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+    save(LaruploadTestModels::HEAVY->instance(), $file);
+
+    Bus::assertDispatched(ProcessMediaDetails::class);
+
+})->with([
+    'video' => fn() => [LaruploadTestModels::HEAVY->instance(), mp4()],
+    'audio' => fn() => [LaruploadTestModels::LIGHT->instance(), mp3()],
+    'image' => fn() => [LaruploadTestModels::HEAVY->instance(), jpg()],
+]);
+
+it('will save video details through queue process', function () {
+    $model = save(LaruploadTestModels::HEAVY->instance(), mp4());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+
+    # test 1
+    expect($queue->record_id)
+        ->toBe($model->id)
+        ->and($queue->record_class)
+        ->toBe($model::class)
+        ->and($queue->status)
+        ->toBe(0)
+        ->and($queue->message)
+        ->toBeNull();
+
+
+    # test 2
+    $meta = $model->attachment('main_file')->meta();
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->width)
+        ->toBeNull()
+        ->and($meta->duration)
+        ->toBeNull()
+        ->and($meta->dominant_color)
+        ->toBeNull();
+
+
+    $process = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+
+    # test 3
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue->record_id)
+        ->toBe($model->id)
+        ->and($queue->record_class)
+        ->toBe($model::class)
+        ->and($queue->status)
+        ->toBe(1)
+        ->and($queue->message)
+        ->toBeNull();
+
+
+    # test 4
+    $model = LaruploadTestModels::HEAVY->instance()->find($model->id);
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBe(LaruploadTestConsts::VIDEO_DETAILS['width'])
+        ->and($meta->height)
+        ->toBe(LaruploadTestConsts::VIDEO_DETAILS['height'])
+        ->and($meta->duration)
+        ->toBe(LaruploadTestConsts::VIDEO_DETAILS['duration'])
+        ->and($meta->dominant_color)
+        ->toBeNull();
+});
+
+it('will save audio details through queue process', function () {
+    $model = save(LaruploadTestModels::LIGHT->instance(), mp3());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+
+    # test 1
+    expect($queue->record_id)
+        ->toBe($model->id)
+        ->and($queue->record_class)
+        ->toBe($model::class)
+        ->and($queue->status)
+        ->toBe(0)
+        ->and($queue->message)
+        ->toBeNull();
+
+
+    # test 2
+    $meta = $model->attachment('main_file')->meta();
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->width)
+        ->toBeNull()
+        ->and($meta->duration)
+        ->toBeNull()
+        ->and($meta->dominant_color)
+        ->toBeNull();
+
+
+    $process = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+
+    # test 3
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue->record_id)
+        ->toBe($model->id)
+        ->and($queue->record_class)
+        ->toBe($model::class)
+        ->and($queue->status)
+        ->toBe(1)
+        ->and($queue->message)
+        ->toBeNull();
+
+
+    # test 4
+    $model = LaruploadTestModels::LIGHT->instance()->find($model->id);
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->height)
+        ->toBeNull()
+        ->and($meta->duration)
+        ->toBe(LaruploadTestConsts::AUDIO_DETAILS['duration'])
+        ->and($meta->dominant_color)
+        ->toBeNull();
+});
+
+it('will save image details through queue process', function () {
+    $model = save(LaruploadTestModels::HEAVY->instance(), jpg());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+
+    # test 1
+    expect($queue->record_id)
+        ->toBe($model->id)
+        ->and($queue->record_class)
+        ->toBe($model::class)
+        ->and($queue->status)
+        ->toBe(0)
+        ->and($queue->message)
+        ->toBeNull();
+
+
+    # test 2
+    $meta = $model->attachment('main_file')->meta();
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->width)
+        ->toBeNull()
+        ->and($meta->duration)
+        ->toBeNull()
+        ->and($meta->dominant_color)
+        ->toBeNull();
+
+
+    $process = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+
+    # test 3
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue->record_id)
+        ->toBe($model->id)
+        ->and($queue->record_class)
+        ->toBe($model::class)
+        ->and($queue->status)
+        ->toBe(1)
+        ->and($queue->message)
+        ->toBeNull();
+
+
+    # test 4
+    $model = LaruploadTestModels::HEAVY->instance()->find($model->id);
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta->width)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->and($meta->height)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
+        ->and($meta->duration)
+        ->toBeNull()
+        ->and($meta->dominant_color)
+        ->toBeNull();
+});
+
+it('will change queue status after processing queue', function () {
+    $model = save(LaruploadTestModels::QUEUE->instance(), jpg());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue)
+        ->toBeObject()
+        ->and($queue->status)
+        ->toBe(0);
+
+    $process = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue)
+        ->toBeObject()
+        ->and($queue->status)
+        ->toBe(1);
+
+});
+
+it('will fire an event when process is finished', function () {
+    $model = save(LaruploadTestModels::QUEUE->instance(), jpg());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    Event::assertNotDispatched(LaruploadMediaDetailsQueueFinished::class);
+
+    $process = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+    $process->handle();
+
+    Event::assertDispatched(LaruploadMediaDetailsQueueFinished::class);
+
+});
+
+
+it('will update queue record with error message, when process failed', function () {
+    $model = save(LaruploadTestModels::QUEUE->instance(), jpg());
+    $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+    expect($queue->message)->toBeNull();
+
+    LaruploadQueueTestModel::where('id', $model->id)->delete();
+
+    try {
+        $process = new ProcessMediaDetails($queue->id, $model->id, 'main_file', $model::class);
+        $process->handle();
+    }
+    catch (Exception $e) {
+        $message = 'Unable to process media details: the model or attached file could not be found.';
+        $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
+
+        expect($e->getMessage())
+            ->toBe($message)
+            ->and($queue->status)
+            ->toBe(0)
+            ->and($queue->message)
+            ->toBe($message);
+    }
+});

--- a/tests/Feature/UploadEntityTest.php
+++ b/tests/Feature/UploadEntityTest.php
@@ -4,6 +4,7 @@ use FFMpeg\Format\Audio\Aac;
 use FFMpeg\Format\Audio\Wav;
 use Mostafaznv\Larupload\Enums\LaruploadImageLibrary;
 use Mostafaznv\Larupload\Enums\LaruploadSecureIdsMethod;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
 use Mostafaznv\Larupload\Test\Support\LaruploadTestConsts;
@@ -156,6 +157,28 @@ it('can change preserve-file property', function () {
     foreach ($paths as $path) {
         expect(file_exists($path))->toBeTrue();
     }
+});
+
+it('can change extract-media-details-on-queue property', function () {
+    # prepare
+    Bus::fake();
+    Queue::fake();
+
+    $this->model->setAttachments([
+        $this->attachment->extractMediaDetailsOnQueue(true)
+    ]);
+
+
+    # test 1
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+
+    # action
+    save($this->model, jpg());
+
+
+    # test 2
+    Bus::assertDispatched(ProcessMediaDetails::class);
 });
 
 it('can change optimize image status', function () {

--- a/tests/Support/LaruploadTestTablesMigration.php
+++ b/tests/Support/LaruploadTestTablesMigration.php
@@ -71,5 +71,20 @@ class LaruploadTestTablesMigration extends Migration
                 $table->timestamp('started_at')->nullable();
                 $table->timestamp('finished_at')->nullable();
             });
+
+
+        $this->app['db']->connection()
+            ->getSchemaBuilder()
+            ->create(Larupload::DETAILS_QUEUE_TABLE, function(Blueprint $table) {
+                $table->id();
+                $table->unsignedInteger('record_id');
+                $table->string('record_class', 50);
+                $table->boolean('status')->default(0);
+                $table->text('message')->nullable();
+
+                $table->timestamp('created_at')->nullable();
+                $table->timestamp('started_at')->nullable();
+                $table->timestamp('finished_at')->nullable();
+            });
     }
 }

--- a/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
+++ b/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
@@ -148,11 +148,12 @@ it('extracts audio metadata correctly', function () {
         ->toBe(LaruploadTestConsts::AUDIO_DETAILS['duration']);
 });
 
-it('wont extract image/audio/video metadata on queue when on ORM mode and postpones it to to after save events', function (UploadedFile $file, LaruploadFileType $type) {
+it('wont extract image/audio/video metadata on queue when it is on ORM mode. it postpones it to the after save events', function (UploadedFile $file, LaruploadFileType $type) {
     # prepare
     Bus::fake(ProcessMediaDetails::class);
     config()->set('larupload.extract-media-details-on-queue', true);
 
+    $this->attachment->extractMediaDetailsOnQueue = true;
     $this->attachment->file = $file;
     $this->attachment->type = $type;
 
@@ -183,6 +184,8 @@ it('wont extract image/audio/video metadata on queue when on ORM mode and postpo
     expect($output->width)
         ->toBeNull()
         ->and($output->height)
+        ->toBeNull()
+        ->and($output->duration)
         ->toBeNull();
 
 })->with([

--- a/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
+++ b/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
@@ -151,7 +151,7 @@ it('extracts audio metadata correctly', function () {
 it('wont extract image/audio/video metadata on queue when on ORM mode and postpones it to to after save events', function (UploadedFile $file, LaruploadFileType $type) {
     # prepare
     Bus::fake(ProcessMediaDetails::class);
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
 
     $this->attachment->file = $file;
     $this->attachment->type = $type;
@@ -194,7 +194,7 @@ it('wont extract image/audio/video metadata on queue when on ORM mode and postpo
 it('wont extract image/audio/video metadata on queue when not on ORM mode', function (UploadedFile $file, LaruploadFileType $type) {
     # prepare
     Bus::fake(ProcessMediaDetails::class);
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
 
     $this->attachment->file = $file;
     $this->attachment->type = $type;

--- a/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
+++ b/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
@@ -148,7 +148,7 @@ it('extracts audio metadata correctly', function () {
         ->toBe(LaruploadTestConsts::AUDIO_DETAILS['duration']);
 });
 
-it('will extract image/audio/video metadata on queue when on ORM mode', function (UploadedFile $file, LaruploadFileType $type) {
+it('wont extract image/audio/video metadata on queue when on ORM mode and postpones it to to after save events', function (UploadedFile $file, LaruploadFileType $type) {
     # prepare
     Bus::fake(ProcessMediaDetails::class);
     config()->set('larupload.fetch-media-details-on-queue', true);
@@ -177,6 +177,13 @@ it('will extract image/audio/video metadata on queue when on ORM mode', function
 
     # test
     Bus::assertDispatched(ProcessMediaDetails::class);
+
+    $output = $this->attachment->output;
+
+    expect($output->width)
+        ->toBeNull()
+        ->and($output->height)
+        ->toBeNull();
 
 })->with([
     fn() => [jpg(), LaruploadFileType::IMAGE],
@@ -210,6 +217,26 @@ it('wont extract image/audio/video metadata on queue when not on ORM mode', func
 
     # test
     Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+    $output = $this->attachment->output;
+
+    if ($type === LaruploadFileType::AUDIO) {
+        expect($output->duration)->toBe(LaruploadTestConsts::AUDIO_DETAILS['duration']);
+    }
+    else if ($type === LaruploadFileType::VIDEO) {
+        expect($output->width)
+            ->toBe(LaruploadTestConsts::VIDEO_DETAILS['width'])
+            ->and($output->height)
+            ->toBe(LaruploadTestConsts::VIDEO_DETAILS['height'])
+            ->and($output->duration)
+            ->toBe(LaruploadTestConsts::VIDEO_DETAILS['duration']);
+    }
+    else {
+        expect($output->width)
+            ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+            ->and($output->height)
+            ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
+    }
 
 })->with([
     fn() => [jpg(), LaruploadFileType::IMAGE],

--- a/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
+++ b/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
@@ -1,10 +1,12 @@
 <?php
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\Actions\Attachment\StoreAttachmentAction;
 use Mostafaznv\Larupload\Enums\LaruploadFileType;
 use Mostafaznv\Larupload\Enums\LaruploadMode;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
 use Mostafaznv\Larupload\Larupload;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
@@ -64,9 +66,12 @@ it('saves basic attachment attributes correctly', function () {
 # media
 it('extracts image metadata correctly', function () {
     $action = new class($this->attachment) extends StoreAttachmentAction {
+        private Model $model;
+
+
         public function run(): void
         {
-            $this->media();
+            $this->media(null);
         }
 
         public function attachment(): Attachment
@@ -94,7 +99,7 @@ it('extracts video metadata correctly', function () {
     $action = new class($this->attachment) extends StoreAttachmentAction {
         public function run(): void
         {
-            $this->media();
+            $this->media(null);
         }
 
         public function attachment(): Attachment
@@ -122,7 +127,7 @@ it('extracts audio metadata correctly', function () {
     $action = new class($this->attachment) extends StoreAttachmentAction {
         public function run(): void
         {
-            $this->media();
+            $this->media(null);
         }
 
         public function attachment(): Attachment
@@ -143,16 +148,88 @@ it('extracts audio metadata correctly', function () {
         ->toBe(LaruploadTestConsts::AUDIO_DETAILS['duration']);
 });
 
+it('will extract image/audio/video metadata on queue when on ORM mode', function (UploadedFile $file, LaruploadFileType $type) {
+    # prepare
+    Bus::fake(ProcessMediaDetails::class);
+    config()->set('larupload.fetch-media-details-on-queue', true);
+
+    $this->attachment->file = $file;
+    $this->attachment->type = $type;
+
+
+    # test
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+
+    # action
+    $action = new class($this->attachment) extends StoreAttachmentAction {
+        public function run(): void
+        {
+            $model = LaruploadTestModels::HEAVY->instance();
+            $model->save();
+
+            $this->media($model);
+        }
+    };
+
+    $action->run();
+
+
+    # test
+    Bus::assertDispatched(ProcessMediaDetails::class);
+
+})->with([
+    fn() => [jpg(), LaruploadFileType::IMAGE],
+    fn() => [mp3(), LaruploadFileType::AUDIO],
+    fn() => [mp4(), LaruploadFileType::VIDEO],
+]);
+
+it('wont extract image/audio/video metadata on queue when not on ORM mode', function (UploadedFile $file, LaruploadFileType $type) {
+    # prepare
+    Bus::fake(ProcessMediaDetails::class);
+    config()->set('larupload.fetch-media-details-on-queue', true);
+
+    $this->attachment->file = $file;
+    $this->attachment->type = $type;
+
+
+    # test
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+
+    # action
+    $action = new class($this->attachment) extends StoreAttachmentAction {
+        public function run(): void
+        {
+            $this->media(null);
+        }
+    };
+
+    $action->run();
+
+
+    # test
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+})->with([
+    fn() => [jpg(), LaruploadFileType::IMAGE],
+    fn() => [mp3(), LaruploadFileType::AUDIO],
+    fn() => [mp4(), LaruploadFileType::VIDEO],
+]);
+
 
 # set-attributes
 it('stores attributes', function () {
     $this->attachment->cover = jpg();
 
     $action = new class($this->attachment) extends StoreAttachmentAction {
+        private ?Model $model = null;
+
+
         public function run(): self
         {
             $this->basic();
-            $this->media();
+            $this->media($this->model);
             $this->setCover($this->attachment->id);
 
             return $this;
@@ -160,6 +237,7 @@ it('stores attributes', function () {
 
         public function set(Model $model, LaruploadMode $mode): Model
         {
+            $this->model = $model;
             $this->attachment->mode = $mode;
 
             return $this->setAttributes($model);

--- a/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
+++ b/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
@@ -35,7 +35,7 @@ beforeEach(function () {
     $this->model->id = 52;
 
 
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
 
     app()->instance(
         InitializeMediaDetailsQueueAction::class,
@@ -81,9 +81,9 @@ it('extract media details for attachments that require extracting on queue', fun
     ]);
 });
 
-it('does not extract media details when `larupload.fetch-media-details-on-queue` is false', function () {
+it('does not extract media details when `larupload.extract-media-details-on-queue` is false', function () {
     # prepare
-    config()->set('larupload.fetch-media-details-on-queue', false);
+    config()->set('larupload.extract-media-details-on-queue', false);
 
 
     # action
@@ -95,7 +95,7 @@ it('does not extract media details when `larupload.fetch-media-details-on-queue`
     expect($attachments)->toBeEmpty();
 
 
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
     ($this->action)($this->model, [$this->attachment]);
 
 

--- a/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
+++ b/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use FFMpeg\Format\Audio\Wav;
+use Mostafaznv\Larupload\Actions\DispatchModelMediaDetailsExtractionAction;
+use Mostafaznv\Larupload\Actions\Queue\InitializeMediaDetailsQueueAction;
+use Mostafaznv\Larupload\DTOs\Style\Output;
+use Mostafaznv\Larupload\Enums\LaruploadFileType;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
+
+
+beforeEach(function () {
+    $this->disk = 'public';
+
+    $this->attachment = Attachment::make('main_file');
+    $this->attachment->disk = $this->disk;
+    $this->attachment->localDisk = $this->disk;
+    $this->attachment->folder = 'test-folder';
+    $this->attachment->nameKebab = 'main-file';
+    $this->attachment->id = 'test-id';
+    $this->attachment->file = mp3();
+    $this->attachment->type = LaruploadFileType::AUDIO;
+    $this->attachment->audio('wav', new Wav);
+
+    $this->attachment->output = Output::make(
+        name: 'test-audio.mp3',
+    );
+
+    $this->path = larupload_relative_path($this->attachment, $this->attachment->id);
+    $this->original = $this->path . '/' . Larupload::ORIGINAL_FOLDER;
+    $this->cover = $this->path . '/' . Larupload::COVER_FOLDER;
+
+    $this->model = LaruploadTestModels::HEAVY->instance();
+    $this->model->id = 52;
+
+
+    config()->set('larupload.fetch-media-details-on-queue', true);
+
+    app()->instance(
+        InitializeMediaDetailsQueueAction::class,
+        new class extends InitializeMediaDetailsQueueAction {
+            private static array $attachments = [];
+
+            public function __construct()
+            {
+                self::$attachments = [];
+            }
+
+            public function __invoke(Attachment $attachment, int $id, string $class): void
+            {
+                self::$attachments[] = $attachment->id;
+            }
+
+            public function getAttachments(): array
+            {
+                return self::$attachments;
+            }
+        }
+    );
+
+    $this->action = resolve(DispatchModelMediaDetailsExtractionAction::class);
+});
+
+
+it('extract media details for attachments that require extracting on queue', function () {
+    # prepare
+    $otherAttachment = clone $this->attachment;
+    $otherAttachment->id = 'other-test-id';
+
+    # action
+    ($this->action)($this->model, [$this->attachment, $otherAttachment]);
+
+
+    # test
+    $attachments = resolve(InitializeMediaDetailsQueueAction::class)->getAttachments();
+
+    expect($attachments)->toBe([
+        'test-id',
+        'other-test-id',
+    ]);
+});
+
+it('does not extract media details when `larupload.fetch-media-details-on-queue` is false', function () {
+    # prepare
+    config()->set('larupload.fetch-media-details-on-queue', false);
+
+
+    # action
+    ($this->action)($this->model, [$this->attachment]);
+
+
+    # test
+    $attachments = resolve(InitializeMediaDetailsQueueAction::class)->getAttachments();
+    expect($attachments)->toBeEmpty();
+
+
+    config()->set('larupload.fetch-media-details-on-queue', true);
+    ($this->action)($this->model, [$this->attachment]);
+
+
+    # test
+    $attachments = resolve(InitializeMediaDetailsQueueAction::class)->getAttachments();
+    expect($attachments)->toBe([
+        'test-id'
+    ]);
+});

--- a/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
+++ b/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
@@ -8,10 +8,13 @@ use Mostafaznv\Larupload\Enums\LaruploadFileType;
 use Mostafaznv\Larupload\Larupload;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadHeavyTestModel;
 
 
 beforeEach(function () {
     $this->disk = 'public';
+
+    config()->set('larupload.extract-media-details-on-queue', true);
 
     $this->attachment = Attachment::make('main_file');
     $this->attachment->disk = $this->disk;
@@ -35,7 +38,6 @@ beforeEach(function () {
     $this->model->id = 52;
 
 
-    config()->set('larupload.extract-media-details-on-queue', true);
 
     app()->instance(
         InitializeMediaDetailsQueueAction::class,
@@ -83,7 +85,7 @@ it('extract media details for attachments that require extracting on queue', fun
 
 it('does not extract media details when `larupload.extract-media-details-on-queue` is false', function () {
     # prepare
-    config()->set('larupload.extract-media-details-on-queue', false);
+    $this->attachment = $this->attachment->extractMediaDetailsOnQueue(false);
 
 
     # action
@@ -95,7 +97,7 @@ it('does not extract media details when `larupload.extract-media-details-on-queu
     expect($attachments)->toBeEmpty();
 
 
-    config()->set('larupload.extract-media-details-on-queue', true);
+    $this->attachment = $this->attachment->extractMediaDetailsOnQueue(true);
     ($this->action)($this->model, [$this->attachment]);
 
 
@@ -103,5 +105,26 @@ it('does not extract media details when `larupload.extract-media-details-on-queu
     $attachments = resolve(InitializeMediaDetailsQueueAction::class)->getAttachments();
     expect($attachments)->toBe([
         'test-id'
+    ]);
+});
+
+it('respects extract-media-details-on-queue based on each attachment object', function () {
+    # prepare
+    $otherAttachment = clone $this->attachment;
+    $otherAttachment->id = 'other-test-id';
+    $otherAttachment = $otherAttachment->extractMediaDetailsOnQueue(true);
+
+    $this->attachment = $this->attachment->extractMediaDetailsOnQueue(false);
+
+
+    # action
+    ($this->action)($this->model, [$this->attachment, $otherAttachment]);
+
+
+    # test
+    $attachments = resolve(InitializeMediaDetailsQueueAction::class)->getAttachments();
+
+    expect($attachments)->toBe([
+        'other-test-id',
     ]);
 });

--- a/tests/Unit/Actions/Queue/HandleFFMpegQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/HandleFFMpegQueueActionTest.php
@@ -31,6 +31,14 @@ beforeEach(function () {
         $this->attachment->output = Output::make(
             name: $name,
         );
+
+        $path = larupload_relative_path($this->attachment, $this->attachment->id, Larupload::ORIGINAL_FOLDER);
+        $fullPath = "$path/{$this->attachment->output->name}";
+
+        $md5 = md5("{$this->attachment->localDisk}/$fullPath");
+        $cacheKey = "larupload:$md5";
+
+        Cache::increment($cacheKey);
     };
 
 
@@ -217,6 +225,13 @@ it('deletes local directory when disk is not local [not-unified attachment ids]'
     $attachment1->output = Output::make(name: 'audio.mp3');
     $attachment1->audio('audio_wav', new Wav);
 
+    $path1 = larupload_relative_path($attachment1, $attachment1->id, Larupload::ORIGINAL_FOLDER);
+    $fullPath1 = "$path1/{$attachment1->output->name}";
+
+    $md5 = md5("$attachment1->localDisk/$fullPath1");
+    $cacheKey1 = "larupload:$md5";
+
+
     $attachment2 = Attachment::make('test_name2');
     $attachment2->id = 'test-id';
     $attachment2->folder = 'test-folder2';
@@ -226,6 +241,13 @@ it('deletes local directory when disk is not local [not-unified attachment ids]'
     $attachment2->secureIdsMethod = $method;
     $attachment2->output = Output::make(name: 'audio.mp3');
     $attachment2->audio('audio_wav', new Wav);
+
+    $path2 = larupload_relative_path($attachment2, $attachment2->id, Larupload::ORIGINAL_FOLDER);
+    $fullPath2 = "$path2/{$attachment2->output->name}";
+
+    $md5 = md5("$attachment2->localDisk/$fullPath2");
+    $cacheKey2 = "larupload:$md5";
+
 
     $path1 = larupload_relative_path($attachment1, $attachment1->id);
     $path2 = larupload_relative_path($attachment2, $attachment2->id);
@@ -238,6 +260,8 @@ it('deletes local directory when disk is not local [not-unified attachment ids]'
     $localStorage->putFileAs($original1, mp3(), 'audio.mp3');
     $localStorage->putFileAs($original2, mp3(), 'audio.mp3');
 
+    Cache::increment($cacheKey1);
+    Cache::increment($cacheKey2);
 
     # before
     $localFiles = $localStorage->allFiles();

--- a/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
@@ -31,6 +31,7 @@ beforeEach(function () {
 
 
     config()->set('larupload.extract-media-details-on-queue', true);
+    config()->set('larupload.dominant-color', true);
 
     $this->action = resolve(HandleMediaDetailsQueueAction::class);
 });
@@ -189,6 +190,59 @@ it('extracts image metadata', function (LaruploadHeavyTestModel|LaruploadLightTe
         ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
         ->toHaveProperty('duration', null)
         ->toHaveProperty('dominant_color', null);
+
+})->with('models');
+
+it('extracts dominant color from image', function (LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    # prepare
+    $model->withDominantColor(true, 1);
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+    $meta = $attachment->meta();
+
+
+    # test 1
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+    # test 2
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 3
+    $meta = $attachment->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', LaruploadTestConsts::IMAGE_DETAILS['jpg']['color']);
+
+    # test 4
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', LaruploadTestConsts::IMAGE_DETAILS['jpg']['color']);
 
 })->with('models');
 

--- a/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
@@ -30,7 +30,7 @@ beforeEach(function () {
     };
 
 
-    config()->set('larupload.fetch-media-details-on-queue', true);
+    config()->set('larupload.extract-media-details-on-queue', true);
 
     $this->action = resolve(HandleMediaDetailsQueueAction::class);
 });

--- a/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
@@ -232,7 +232,9 @@ it('extracts dominant color from image', function (LaruploadHeavyTestModel|Larup
         ->toHaveProperty('width', LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
         ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
         ->toHaveProperty('duration', null)
-        ->toHaveProperty('dominant_color', LaruploadTestConsts::IMAGE_DETAILS['jpg']['color']);
+        ->and($meta->dominant_color)
+        ->toBeTruthy()
+        ->toMatch(LaruploadTestConsts::HEX_REGEX);
 
     # test 4
     $model->refresh();
@@ -242,7 +244,9 @@ it('extracts dominant color from image', function (LaruploadHeavyTestModel|Larup
         ->toHaveProperty('width', LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
         ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
         ->toHaveProperty('duration', null)
-        ->toHaveProperty('dominant_color', LaruploadTestConsts::IMAGE_DETAILS['jpg']['color']);
+        ->and($meta->dominant_color)
+        ->toBeTruthy()
+        ->toMatch(LaruploadTestConsts::HEX_REGEX);
 
 })->with('models');
 

--- a/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
@@ -1,0 +1,335 @@
+<?php
+
+use Mostafaznv\Larupload\Actions\Queue\HandleMediaDetailsQueueAction;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Test\Support\LaruploadTestConsts;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadHeavyTestModel;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadLightTestModel;
+use Mostafaznv\Larupload\Test\Support\Models\LaruploadRemoteQueueTestModel;
+
+
+beforeEach(function () {
+    $this->disk = 'public';
+
+    Queue::fake(ProcessMediaDetails::class);
+    Storage::fake('s3');
+    Storage::fake($this->disk);
+    $this->storage = Storage::disk($this->disk);
+
+
+    $this->getAttachment = function (LaruploadHeavyTestModel|LaruploadLightTestModel|LaruploadRemoteQueueTestModel $model): Attachment {
+        $attachment = $model->attachment('main_file');
+
+        $reflection = new ReflectionClass($attachment);
+        $property = $reflection->getProperty('attachment');
+        $property->setAccessible(true);
+
+        return $property->getValue($attachment);
+    };
+
+
+    config()->set('larupload.fetch-media-details-on-queue', true);
+
+    $this->action = resolve(HandleMediaDetailsQueueAction::class);
+});
+
+
+it('extracts video metadata and saves to model', function (LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    # prepare
+    $model->attachment('main_file')->attach(mp4());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+    $meta = $attachment->meta();
+
+
+    # test 1
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+    # test 2
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 3
+    $meta = $attachment->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', LaruploadTestConsts::VIDEO_DETAILS['width'])
+        ->toHaveProperty('height', LaruploadTestConsts::VIDEO_DETAILS['height'])
+        ->toHaveProperty('duration', LaruploadTestConsts::VIDEO_DETAILS['duration'])
+        ->toHaveProperty('dominant_color', null);
+
+    # test 4
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', LaruploadTestConsts::VIDEO_DETAILS['width'])
+        ->toHaveProperty('height', LaruploadTestConsts::VIDEO_DETAILS['height'])
+        ->toHaveProperty('duration', LaruploadTestConsts::VIDEO_DETAILS['duration'])
+        ->toHaveProperty('dominant_color', null);
+
+})->with('models');
+
+it('extracts audio metadata and saves to model', function (LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    # prepare
+    $model->attachment('main_file')->attach(mp3());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+    $meta = $attachment->meta();
+
+
+    # test 1
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+    # test 2
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 3
+    $meta = $attachment->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', LaruploadTestConsts::AUDIO_DETAILS['duration'])
+        ->toHaveProperty('dominant_color', null);
+
+    # test 4
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', LaruploadTestConsts::AUDIO_DETAILS['duration'])
+        ->toHaveProperty('dominant_color', null);
+
+})->with('models');
+
+it('extracts image metadata', function (LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    # prepare
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+    $meta = $attachment->meta();
+
+
+    # test 1
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+    # test 2
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', null)
+        ->toHaveProperty('height', null)
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 3
+    $meta = $attachment->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+    # test 4
+    $model->refresh();
+    $meta = $model->attachment('main_file')->meta();
+
+    expect($meta)
+        ->toHaveProperty('width', LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->toHaveProperty('height', LaruploadTestConsts::IMAGE_DETAILS['jpg']['height'])
+        ->toHaveProperty('duration', null)
+        ->toHaveProperty('dominant_color', null);
+
+})->with('models');
+
+it('calls delete_local_copy after processing but since driver is local, wont delete anything', function (LaruploadHeavyTestModel|LaruploadLightTestModel $model) {
+    # prepare
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+
+    $basePath = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+    $path = $basePath . '/' . $attachment->output->name;
+    $disk = $attachment->disk;
+    $driverIsLocal = disk_driver_is_local($attachment->disk);
+    $md5 = md5("$disk/$path");
+    $cacheKey = "larupload:$md5";
+
+    Cache::increment($cacheKey);
+
+
+    # test 1
+    expect($driverIsLocal)->toBeTrue();
+
+
+    # test 2
+    $exists = Storage::disk($attachment->disk)->exists($path);
+    expect($exists)->toBeTrue();
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 3
+    $exists = Storage::disk($attachment->disk)->exists($path);
+    expect($exists)->toBeTrue();
+
+})->with('models');
+
+
+it('calls delete_local_copy after processing and deletes local file when the driver is not local', function () {
+    # prepare
+    $model = new LaruploadRemoteQueueTestModel;
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+
+    $basePath = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+    $path = $basePath . '/' . $attachment->output->name;
+    $disk = $attachment->disk;
+    $driverIsLocal = disk_driver_is_local($disk);
+    $md5 = md5("$disk/$path");
+    $cacheKey = "larupload:$md5";
+
+    Cache::increment($cacheKey);
+
+
+    # test 1
+    expect($driverIsLocal)->toBeFalse();
+
+
+    # test 2
+    $exists = Storage::disk($attachment->localDisk)->exists($path);
+    expect($exists)->toBeTrue();
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 3
+    $exists = Storage::disk($attachment->localDisk)->exists($path);
+    expect($exists)->toBeFalse();
+
+})->with('models');
+
+it('saves video metadata to model [heavy]', function () {
+    # prepare
+    $model = new LaruploadHeavyTestModel;
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+
+
+    # test 1
+    $model->refresh();
+
+    expect($model->getAttribute('main_file_file_width'))
+        ->toBeNull()
+        ->and($model->getAttribute('main_file_file_height'))
+        ->toBeNull();
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 2
+    $model->refresh();
+
+
+    expect($model->getAttribute('main_file_file_width'))
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->and($model->getAttribute('main_file_file_height'))
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
+
+});
+
+
+it('saves video metadata to model [light]', function () {
+    # prepare
+    $model = new LaruploadLightTestModel;
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+
+
+    # test 1
+    $model->refresh();
+    $meta = json_decode($model->getAttribute('main_file_file_meta'));
+
+    expect($meta->width)
+        ->toBeNull()
+        ->and($meta->height)
+        ->toBeNull();
+
+
+    # action
+    $this->action->execute($model, $attachment);
+
+
+    # test 2
+    $model->refresh();
+    $meta = json_decode($model->getAttribute('main_file_file_meta'));
+
+
+    expect($meta->width)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['width'])
+        ->and($meta->height)
+        ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
+});

--- a/tests/Unit/Actions/Queue/InitializeMediaDetailsQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/InitializeMediaDetailsQueueActionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Bus;
+use Mostafaznv\Larupload\Actions\Queue\InitializeMediaDetailsQueueAction;
+use Mostafaznv\Larupload\DTOs\Style\Output;
+use Mostafaznv\Larupload\Jobs\ProcessMediaDetails;
+use Mostafaznv\Larupload\Larupload;
+use Mostafaznv\Larupload\Storage\Attachment;
+use Mostafaznv\Larupload\Test\Support\Enums\LaruploadTestModels;
+
+
+beforeEach(function () {
+    $this->disk = 'public';
+
+    Bus::fake();
+    Queue::fake();
+    Storage::fake($this->disk);
+    Storage::fake('s3');
+
+    $this->attachment = Attachment::make('test_name');
+    $this->attachment->id = 'test-id';
+    $this->attachment->folder = 'test-folder';
+    $this->attachment->nameKebab = 'test-name';
+    $this->attachment->disk = $this->disk;
+    $this->attachment->localDisk = $this->disk;
+    $this->attachment->output = Output::make(
+        name: 'video.mp4',
+    );
+
+    $this->table = DB::table(Larupload::DETAILS_QUEUE_TABLE);
+
+    $this->action = resolve(InitializeMediaDetailsQueueAction::class);
+});
+
+
+it('dispatches media details job', function () {
+    # before
+    Bus::assertNotDispatched(ProcessMediaDetails::class);
+
+
+    # action
+    $model = LaruploadTestModels::HEAVY->instance()->getMorphClass();
+    ($this->action)($this->attachment, 54, $model);
+
+
+    # test
+    Bus::assertDispatched(ProcessMediaDetails::class);
+});
+
+it('stores a record for the dispatched queue', function () {
+    # before
+    $count = $this->table->count();
+    expect($count)->toBe(0);
+
+
+    # action
+    $model = LaruploadTestModels::HEAVY->instance()->getMorphClass();
+    ($this->action)($this->attachment, 54, $model);
+
+
+    # test
+    $items = $this->table->get();
+    $queue = $items->first();
+    $files = Storage::disk($this->attachment->disk)->allFiles();
+
+    expect($files)
+        ->toBeEmpty()
+        ->and($items)
+        ->toHaveCount(1)
+        ->and($queue->record_id)
+        ->toBe(54)
+        ->and($queue->record_class)
+        ->toBe($model)
+        ->and($queue->status)
+        ->toBe(0)
+        ->and($queue->message)
+        ->toBeNull();
+});
+
+it('saves file locally when disk is not local', function () {
+    $this->attachment->disk = 's3';
+    $this->attachment->localDisk = $this->disk;
+    $this->attachment->file = mp4();
+
+
+    # before
+    $localFiles = Storage::disk($this->attachment->localDisk)->allFiles();
+    expect($localFiles)->toBeEmpty();
+
+
+    # action
+    $model = LaruploadTestModels::HEAVY->instance()->getMorphClass();
+    ($this->action)($this->attachment, 54, $model);
+
+
+    # test
+    $localFiles = Storage::disk($this->attachment->localDisk)->allFiles();
+    $remoteFiles = Storage::disk($this->attachment->disk)->allFiles();
+    $original = larupload_relative_path($this->attachment, 'test-id', Larupload::ORIGINAL_FOLDER);
+    $items = $this->table->get();
+    $queue = $items->first();
+
+    expect($remoteFiles)
+        ->toBeEmpty()
+        ->and($localFiles)
+        ->toHaveCount(1)
+        ->toBe([
+            "$original/video.mp4",
+        ])
+        ->and($items)
+        ->toHaveCount(1)
+        ->and($queue->record_id)
+        ->toBe(54)
+        ->and($queue->record_class)
+        ->toBe($model)
+        ->and($queue->status)
+        ->toBe(0)
+        ->and($queue->message)
+        ->toBeNull();
+});
+
+it('doesnt save a local copy when disk is local', function () {
+    $this->attachment->disk = 'public';
+    $this->attachment->localDisk = $this->disk;
+    $this->attachment->file = mp4();
+
+
+    # before
+    $localFiles = Storage::disk($this->attachment->localDisk)->allFiles();
+    expect($localFiles)->toBeEmpty();
+
+
+    # action
+    $model = LaruploadTestModels::HEAVY->instance()->getMorphClass();
+    ($this->action)($this->attachment, 54, $model);
+
+
+    # test
+    $localFiles = Storage::disk($this->attachment->localDisk)->allFiles();
+    $remoteFiles = Storage::disk($this->attachment->disk)->allFiles();
+
+    expect($remoteFiles)
+        ->toBeEmpty()
+        ->and($localFiles)
+        ->toBeEmpty();
+});
+

--- a/tests/Unit/Helpers/UtilsTest.php
+++ b/tests/Unit/Helpers/UtilsTest.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
+use Mostafaznv\Larupload\DTOs\Style\Output;
 use Mostafaznv\Larupload\Enums\LaruploadMode;
+use Mostafaznv\Larupload\Larupload;
 use Mostafaznv\Larupload\Storage\Attachment;
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -302,3 +304,79 @@ it('trims slashes from folder and path with folder', function () {
 
     expect($result)->toBe('uploads/123/example-file/folder');
 });
+
+
+# local copy
+it('does not create a local copy when the disk is local', function () {
+    Storage::fake('local');
+
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 'local';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $result = local_copy($attachment);
+
+    expect($result)
+        ->toBeNull()
+        ->and(Storage::disk('local')->allFiles())
+        ->toBeEmpty();
+});
+
+it('creates a local copy for remote disks and returns the file hash', function () {
+    Storage::fake('local');
+    Storage::fake('s3');
+
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 's3';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $expectedHash = md5_file($attachment->file->getRealPath());
+    $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+
+    $result = local_copy($attachment);
+
+    expect($result)
+        ->toBe($expectedHash)
+        ->and(Storage::disk('local')->exists("$path/file.pdf"))
+        ->toBeTrue()
+        ->and(Storage::disk('local')->get("$path/file.pdf"))
+        ->toBe(file_get_contents($attachment->file->getRealPath()));
+});
+
+it('does not overwrite an existing local copy and still returns the file hash', function () {
+    Storage::fake('local');
+    Storage::fake('s3');
+
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 's3';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $expectedHash = md5_file($attachment->file->getRealPath());
+    $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+    Storage::disk('local')->put("$path/file.pdf", 'existing-content');
+
+    $result = local_copy($attachment);
+
+    expect($result)
+        ->toBe($expectedHash)
+        ->and(Storage::disk('local')->get("$path/file.pdf"))
+        ->toBe('existing-content')
+        ->and(Storage::disk('local')->allFiles())
+        ->toBe(["$path/file.pdf"]);
+});
+

--- a/tests/Unit/Helpers/UtilsTest.php
+++ b/tests/Unit/Helpers/UtilsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Mostafaznv\Larupload\DTOs\Style\Output;
 use Mostafaznv\Larupload\Enums\LaruploadMode;
@@ -307,7 +308,7 @@ it('trims slashes from folder and path with folder', function () {
 
 
 # local copy
-it('does not create a local copy when the disk is local', function () {
+it('returns false when the disk is local', function () {
     Storage::fake('local');
 
     $attachment = Attachment::make('example_file');
@@ -322,12 +323,12 @@ it('does not create a local copy when the disk is local', function () {
     $result = local_copy($attachment);
 
     expect($result)
-        ->toBeNull()
+        ->toBeFalse()
         ->and(Storage::disk('local')->allFiles())
         ->toBeEmpty();
 });
 
-it('creates a local copy for remote disks and returns the file hash', function () {
+it('creates a local copy for remote disks and returns true', function () {
     Storage::fake('local');
     Storage::fake('s3');
 
@@ -340,20 +341,19 @@ it('creates a local copy for remote disks and returns the file hash', function (
     $attachment->file = pdf();
     $attachment->output = Output::make(name: 'file.pdf');
 
-    $expectedHash = md5_file($attachment->file->getRealPath());
     $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
 
     $result = local_copy($attachment);
 
     expect($result)
-        ->toBe($expectedHash)
+        ->toBeTrue()
         ->and(Storage::disk('local')->exists("$path/file.pdf"))
         ->toBeTrue()
         ->and(Storage::disk('local')->get("$path/file.pdf"))
         ->toBe(file_get_contents($attachment->file->getRealPath()));
 });
 
-it('does not overwrite an existing local copy and still returns the file hash', function () {
+it('returns true when a local copy already exists', function () {
     Storage::fake('local');
     Storage::fake('s3');
 
@@ -366,17 +366,49 @@ it('does not overwrite an existing local copy and still returns the file hash', 
     $attachment->file = pdf();
     $attachment->output = Output::make(name: 'file.pdf');
 
-    $expectedHash = md5_file($attachment->file->getRealPath());
     $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
     Storage::disk('local')->put("$path/file.pdf", 'existing-content');
 
     $result = local_copy($attachment);
 
     expect($result)
-        ->toBe($expectedHash)
+        ->toBeTrue()
         ->and(Storage::disk('local')->get("$path/file.pdf"))
-        ->toBe('existing-content')
-        ->and(Storage::disk('local')->allFiles())
-        ->toBe(["$path/file.pdf"]);
+        ->toBe('existing-content');
 });
 
+it('returns false when `putFileAs` fails', function () {
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 's3';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $storage = Mockery::mock();
+    $storage->shouldReceive('exists')->once()->andReturnFalse();
+    $storage->shouldReceive('putFileAs')->once()->andReturnFalse();
+
+    $lock = Mockery::mock();
+    $lock->shouldReceive('block')
+        ->once()
+        ->with(5, Mockery::type(Closure::class))
+        ->andReturnUsing(function (int $seconds, Closure $callback) {
+            return $callback();
+        });
+
+    Storage::shouldReceive('disk')
+        ->once()
+        ->with('local')
+        ->andReturn($storage);
+
+    Cache::shouldReceive('lock')
+        ->once()
+        ->andReturn($lock);
+
+    $result = local_copy($attachment);
+
+    expect($result)->toBeFalse();
+});

--- a/tests/Unit/Helpers/UtilsTest.php
+++ b/tests/Unit/Helpers/UtilsTest.php
@@ -412,3 +412,85 @@ it('returns false when `putFileAs` fails', function () {
 
     expect($result)->toBeFalse();
 });
+
+
+# delete local copy
+it('returns false when the disk is local for delete_local_copy', function () {
+    Storage::fake('local');
+
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 'local';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $result = delete_local_copy($attachment);
+
+    expect($result)->toBeFalse();
+});
+
+it('returns false when cache key is missing in delete_local_copy', function () {
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 's3';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $result = delete_local_copy($attachment);
+
+    expect($result)->toBeFalse();
+});
+
+it('forgets cache and deletes directory when cache value is <= 1', function () {
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 's3';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+    $fullPath = "$path/{$attachment->output->name}";
+    $md5 = md5("$attachment->localDisk/$fullPath");
+    $cacheKey = "larupload:$md5";
+
+    Cache::increment($cacheKey);
+
+    $result = delete_local_copy($attachment);
+
+    expect($result)->toBeTrue();
+});
+
+it('decrements cache and returns false when cache value is greater than 1', function () {
+    $attachment = Attachment::make('example_file');
+    $attachment->disk = 's3';
+    $attachment->localDisk = 'local';
+    $attachment->folder = 'uploads';
+    $attachment->nameKebab = 'example-file';
+    $attachment->id = '123';
+    $attachment->file = pdf();
+    $attachment->output = Output::make(name: 'file.pdf');
+
+    $path = larupload_relative_path($attachment, $attachment->id, Larupload::ORIGINAL_FOLDER);
+    $fullPath = "$path/{$attachment->output->name}";
+    $md5 = md5("$attachment->localDisk/$fullPath");
+    $cacheKey = "larupload:$md5";
+
+    Cache::increment($cacheKey, 5);
+
+    $result = delete_local_copy($attachment);
+    expect($result)->toBeFalse();
+
+
+    $value = Cache::get($cacheKey);
+    expect($value)->toBe(4);
+});
+


### PR DESCRIPTION
This pull request introduces asynchronous extraction of media details (like duration and resolution) using Laravel's queue system, improving upload performance for large files. It adds configuration options, documentation, a new migration, and the necessary queue/job logic to support this feature. When enabled, media details are extracted after upload via a queued job, and related events and relationships are provided for monitoring and responding to extraction completion.

