### PR TITLE
Dev

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -61,13 +61,8 @@ jobs:
           key: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-ImageMagick-${{ matrix.imagemagick }}-
 
-      - name: Check ImageMagick cache exists
-        uses: andstor/file-existence-action@v3
-        id: cache-imagemagick-exists
-        with:
-          files: /home/runner/im/imagemagick-${{ matrix.imagemagick }}
-
       - name: Install ImageMagick
+        if: steps.cache-imagemagick.outputs.cache-hit != 'true'
         run: |
           curl -o /tmp/ImageMagick.tar.gz -sL https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${{ matrix.imagemagick }}.tar.gz
           (
@@ -79,20 +74,33 @@ jobs:
             sudo make install
           )
 
-      - name: Install PHP ImageMagick extension
+      - name: Cache Imagick PHP extension
+        uses: actions/cache@v4
+        id: cache-imagick-ext
+        with:
+          path: /home/runner/imagick-ext/imagick-${{ matrix.imagick }}-php${{ matrix.php }}
+          key: ${{ runner.os }}-imagick-ext-${{ matrix.imagick }}-php${{ matrix.php }}-${{ matrix.imagemagick }}
+
+      - name: Build Imagick PHP extension
+        if: steps.cache-imagick-ext.outputs.cache-hit != 'true'
         run: |
           curl -o /tmp/imagick.tgz -sL http://pecl.php.net/get/imagick-${{ matrix.imagick }}.tgz
+          mkdir -p /home/runner/imagick-ext/imagick-${{ matrix.imagick }}-php${{ matrix.php }}
           (
             cd /tmp || exit 1
             tar -xzf imagick.tgz
             cd imagick-${{ matrix.imagick }}
             phpize
-            sudo ./configure --with-imagick=/home/runner/im/imagemagick-${{ matrix.imagemagick }}
-            sudo make -j$(nproc)
-            sudo make install
+            ./configure --with-imagick=/home/runner/im/imagemagick-${{ matrix.imagemagick }}
+            make -j$(nproc)
+            cp modules/imagick.so /home/runner/imagick-ext/imagick-${{ matrix.imagick }}-php${{ matrix.php }}/imagick.so
           )
+
+      - name: Enable Imagick PHP extension
+        run: |
+          sudo cp /home/runner/imagick-ext/imagick-${{ matrix.imagick }}-php${{ matrix.php }}/imagick.so "$(php -r 'echo ini_get("extension_dir");')/imagick.so"
           sudo bash -c 'echo "extension=imagick.so" >> /etc/php/${{ matrix.php }}/cli/php.ini'
-          php --ri imagick;
+          php --ri imagick
 
       - name: Cache dependencies
         uses: actions/cache@v4

--- a/docs/other/migration.md
+++ b/docs/other/migration.md
@@ -1,5 +1,23 @@
 # Migration
 
+#### From 3.3.0 to 3.4.0
+
+Starting from version 3.4.0, Larupload can extract media details (video, audio, and image metadata) such as width, height, duration, and more using a queue. This significantly improves upload performance.
+
+To use this feature, you should add the [`extract-media-details-on-queue`](https://github.com/mostafaznv/larupload/blob/master/config/config.php#L215-L229) option to your published `config/larupload.php` file.
+
+You should also publish the migrations to create the `larupload_details_queue` table:
+
+```bash
+php artisan vendor:publish --provider="Mostafaznv\Larupload\LaruploadServiceProvider"
+```
+
+```bash
+php artisan migrate
+```
+
+<br>
+
 #### From 2.3.4 to 3.0.0
 
 Starting from version 3.0.0, support for PHP 8.1 and 8.2 has been dropped, along with support for Laravel 10 and 11.
@@ -10,15 +28,11 @@ In legacy versions, the `LARUPLOAD_NULL` constant was used to delete files. As o
 
 Finally, the behavior of the FFMpeg queue has been updated. Previously, an `HttpResponseException` was thrown when the queue limit was exceeded. From version 3.0.0 onward, the package throws `FFMpegQueueMaxNumExceededException` instead.
 
-
-
-
-
 #### From 2.1.0 to 2.2.0
 
 Starting from version 2.2.0, we added functionality to the package to store the original file name in the database.
 
-Since the old `name` column was used to store the manipulated file name (hashed, unique id, time, etc.), we needed a new column to store the original one.&#x20;
+Since the old `name` column was used to store the manipulated file name (hashed, unique id, time, etc.), we needed a new column to store the original one.
 
 Adding a new column and working with it could result in a breaking change, so we decided to make it optional. In the next major release, we will make it the default behavior of the package.
 
@@ -26,6 +40,3 @@ To enable this feature:
 
 1. Enable the `store-original-file-name` property in the [`config/larupload.php`](../advanced-usage/configuration/store-original-file-name.md) file. (You may need to add it to your config file from [here](https://github.com/mostafaznv/larupload/blob/b3392af87d902a133a962daf223a97a93c566482/config/config.php#L217-L227))
 2. Add the `{$name}_file_original_name` column to your existing tables. (for new tables, this column will be added by default).
-
-
-

--- a/src/Actions/DispatchModelMediaDetailsExtractionAction.php
+++ b/src/Actions/DispatchModelMediaDetailsExtractionAction.php
@@ -3,6 +3,7 @@
 namespace Mostafaznv\Larupload\Actions;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
 use Mostafaznv\Larupload\Actions\Queue\InitializeMediaDetailsQueueAction;
 use Mostafaznv\Larupload\Storage\Attachment;
 
@@ -16,11 +17,17 @@ class DispatchModelMediaDetailsExtractionAction
     public function __invoke(Model $model, array $attachments): void
     {
         foreach ($attachments as $attachment) {
-            if ($attachment->extractMediaDetailsOnQueue) {
+            if ($this->shouldExtractMediaDetailsOnQueue($attachment)) {
                 resolve(InitializeMediaDetailsQueueAction::class)(
                     $attachment, $model->id, $model->getMorphClass()
                 );
             }
         }
+    }
+
+    private function shouldExtractMediaDetailsOnQueue(Attachment $attachment): bool
+    {
+        return $attachment->extractMediaDetailsOnQueue
+            and $attachment->file instanceof UploadedFile;
     }
 }

--- a/src/Actions/DispatchModelMediaDetailsExtractionAction.php
+++ b/src/Actions/DispatchModelMediaDetailsExtractionAction.php
@@ -28,6 +28,7 @@ class DispatchModelMediaDetailsExtractionAction
     private function shouldExtractMediaDetailsOnQueue(Attachment $attachment): bool
     {
         return $attachment->extractMediaDetailsOnQueue
+            and isset($attachment->file)
             and $attachment->file instanceof UploadedFile;
     }
 }

--- a/src/Actions/Queue/HandleMediaDetailsQueueAction.php
+++ b/src/Actions/Queue/HandleMediaDetailsQueueAction.php
@@ -10,6 +10,7 @@ use Mostafaznv\Larupload\Larupload;
 use Mostafaznv\Larupload\Storage\Attachment;
 use Mostafaznv\Larupload\Storage\FFMpeg\FFMpeg;
 use Mostafaznv\Larupload\Storage\Image;
+use RuntimeException;
 
 
 class HandleMediaDetailsQueueAction
@@ -63,9 +64,15 @@ class HandleMediaDetailsQueueAction
         $path = $basePath . '/' . $attachment->output->name;
         $disk = disk_driver_is_local($attachment->disk) ? $attachment->disk : $attachment->localDisk;
 
-        $path = Storage::disk($disk)->path($path);
+        $exists = Storage::disk($disk)->exists($path);
 
-        return new UploadedFile($path, $attachment->output->name, null, null, true);
+        if ($exists) {
+            $path = Storage::disk($disk)->path($path);
+
+            return new UploadedFile($path, $attachment->output->name, null, null, true);
+        }
+
+        throw new RuntimeException("File not found on disk: $disk, path: $path");
     }
 
     private function ffmpeg(Attachment $attachment): FFMpeg

--- a/tests/Feature/MediaDetailsQueueTest.php
+++ b/tests/Feature/MediaDetailsQueueTest.php
@@ -238,9 +238,7 @@ it('will update queue record with error message, when process failed', function 
     catch (Exception $e) {
         $message = $e->getMessage();
 
-        expect($message)
-            ->toStartWith('The file')
-            ->toEndWith('does not exist');
+        expect($message)->toStartWith('File not found on disk: local, path: upload-heavy');
 
         $queue = DB::table(Larupload::DETAILS_QUEUE_TABLE)->first();
         expect($queue->message)->toBe($message);

--- a/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
+++ b/tests/Unit/Actions/Attachment/StoreAttachmentActionTest.php
@@ -167,6 +167,7 @@ it('wont extract image/audio/video metadata on queue when it is on ORM mode. it 
         public function run(): void
         {
             $model = LaruploadTestModels::HEAVY->instance();
+            $model->attachment('main_file')->attach($this->attachment->file);
             $model->save();
 
             $this->media($model);

--- a/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
+++ b/tests/Unit/Actions/DispatchModelMediaDetailsExtractionActionTest.php
@@ -128,3 +128,23 @@ it('respects extract-media-details-on-queue based on each attachment object', fu
         'other-test-id',
     ]);
 });
+
+it('wont dispatch `DispatchModelMediaDetailsExtractionAction` when there is not file attached to the attachment', function () {
+    # prepare
+    $otherAttachment = clone $this->attachment;
+    $otherAttachment->id = 'other-test-id';
+
+    $this->attachment->file = false;
+
+
+    # action
+    ($this->action)($this->model, [$this->attachment, $otherAttachment]);
+
+
+    # test
+    $attachments = resolve(InitializeMediaDetailsQueueAction::class)->getAttachments();
+
+    expect($attachments)->toBe([
+        'other-test-id',
+    ]);
+});

--- a/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
+++ b/tests/Unit/Actions/Queue/HandleMediaDetailsQueueActionTest.php
@@ -391,3 +391,48 @@ it('saves video metadata to model [light]', function () {
         ->and($meta->height)
         ->toBe(LaruploadTestConsts::IMAGE_DETAILS['jpg']['height']);
 });
+
+it('throws an error when the local file does not exist', function () {
+    # prepare
+    $model = new LaruploadLightTestModel;
+    $model->attachment('main_file')->attach(jpg());
+    $model->save();
+
+    $attachment = ($this->getAttachment)($model);
+
+    Storage::disk('local')->deleteDirectory('/');
+
+
+    # action
+    try {
+        $this->action->execute($model, $attachment);
+
+        expect(true)->toBeFalse();
+    }
+    catch (Exception $e) {
+        # test 1
+        expect($e)
+            ->toBeInstanceOf(RuntimeException::class)
+            ->and($e->getMessage())
+            ->toStartWith('File not found on disk: local, path: upload-light/');
+
+
+        # test 2
+        $meta = $attachment->meta();
+        expect($meta)
+            ->toHaveProperty('width', null)
+            ->toHaveProperty('height', null)
+            ->toHaveProperty('duration', null)
+            ->toHaveProperty('dominant_color', null);
+
+        # test 3
+        $model->refresh();
+        $meta = $model->attachment('main_file')->meta();
+
+        expect($meta)
+            ->toHaveProperty('width', null)
+            ->toHaveProperty('height', null)
+            ->toHaveProperty('duration', null)
+            ->toHaveProperty('dominant_color', null);
+    }
+});


### PR DESCRIPTION
This pull request introduces improvements to the media details extraction queue feature, enhances error handling for missing files, and updates related documentation and tests to ensure reliability and clarity.

**Media details extraction improvements:**

* The `DispatchModelMediaDetailsExtractionAction` now checks if an actual file is attached and is an instance of `UploadedFile` before dispatching media details extraction to the queue, preventing unnecessary queue jobs.
* Tests have been added and updated to verify that the extraction action is only dispatched when appropriate, and that it is skipped if no file is attached.

**Error handling enhancements:**

* In `HandleMediaDetailsQueueAction`, a `RuntimeException` is now thrown with a clear message if the file to be processed does not exist on disk, improving error traceability.
* Unit and feature tests have been updated to expect the new error message and exception type, ensuring that missing file scenarios are properly handled and reported. [[1]](diffhunk://#diff-8f18f6fcf0836b7677e70aca34dfd8a3fec5f4393e9c5227d98086ad43840feeL241-R241) [[2]](diffhunk://#diff-b84c5e919ee0bd0ea75943e95b8ffafaa6c6503aae554fe336fe1ccfba4a12bbR394-R438)

**Documentation updates:**

* The migration guide has been updated with instructions for enabling the new media details extraction queue feature, including configuration and migration steps for version 3.4.0.
* Minor formatting corrections and clarifications were made to the migration documentation for better readability.